### PR TITLE
fix(mcp): remove unnecessary Kubernetes API details from namespace tool

### DIFF
--- a/pkg/mcp/namespaces.go
+++ b/pkg/mcp/namespaces.go
@@ -15,8 +15,6 @@ func (s *Server) initNamespaces() []server.ServerTool {
 	ret = append(ret, server.ServerTool{
 		Tool: mcp.NewTool("namespaces_list",
 			mcp.WithDescription("List all the Kubernetes namespaces in the current cluster"),
-			mcp.WithString("k8surl", mcp.Description("Kubernetes API server URL"), mcp.Required()),
-			mcp.WithString("k8stoken", mcp.Description("Kubernetes API server authentication token"), mcp.Required()),
 		), Handler: s.namespacesList,
 	})
 	return ret


### PR DESCRIPTION
- Removed the requirement for Kubernetes API server URL and authentication token in the \'namespaces_list\' tool.
- This change simplifies the tool configuration by eliminating redundant parameters.
- Ensures that the tool functions without needing explicit API server details, relying on default configurations.