### PR TITLE
refactor: enhance Kubernetes resource listing functions to support pagination with limit and continue token

### DIFF
--- a/pkg/kubernetes/namespaces.go
+++ b/pkg/kubernetes/namespaces.go
@@ -6,8 +6,8 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
-func (k *Kubernetes) NamespacesList(ctx context.Context) (string, error) {
+func (k *Kubernetes) NamespacesList(ctx context.Context, limit int64, continueToken string) (string, error) {
 	return k.ResourcesList(ctx, &schema.GroupVersionKind{
 		Group: "", Version: "v1", Kind: "Namespace",
-	}, "")
+	}, "", limit, continueToken)
 }

--- a/pkg/kubernetes/pods.go
+++ b/pkg/kubernetes/pods.go
@@ -9,16 +9,16 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
-func (k *Kubernetes) PodsListInAllNamespaces(ctx context.Context) (string, error) {
+func (k *Kubernetes) PodsListInAllNamespaces(ctx context.Context, limit int64, continueToken string) (string, error) {
 	return k.ResourcesList(ctx, &schema.GroupVersionKind{
 		Group: "", Version: "v1", Kind: "Pod",
-	}, "")
+	}, "", limit, continueToken)
 }
 
-func (k *Kubernetes) PodsListInNamespace(ctx context.Context, namespace string) (string, error) {
+func (k *Kubernetes) PodsListInNamespace(ctx context.Context, namespace string, limit int64, continueToken string) (string, error) {
 	return k.ResourcesList(ctx, &schema.GroupVersionKind{
 		Group: "", Version: "v1", Kind: "Pod",
-	}, namespace)
+	}, namespace, limit, continueToken)
 }
 
 func (k *Kubernetes) PodsGet(ctx context.Context, namespace, name string) (string, error) {

--- a/pkg/kubernetes/resources.go
+++ b/pkg/kubernetes/resources.go
@@ -54,11 +54,13 @@ func getResourceTypeFromGVK(gvk *schema.GroupVersionKind) string {
 	return strings.ToLower(gvk.Kind) + "." + gvk.Group
 }
 
-func (k *Kubernetes) ResourcesList(ctx context.Context, gvk *schema.GroupVersionKind, namespace string) (string, error) {
+func (k *Kubernetes) ResourcesList(ctx context.Context, gvk *schema.GroupVersionKind, namespace string, limit int64, continueToken string) (string, error) {
 	// Create a JSON payload for the list-resources endpoint
 	requestBody := map[string]interface{}{
 		"apiVersion": gvk.GroupVersion().String(),
 		"kind":       gvk.Kind,
+		"limit":      limit,
+		"continue":   continueToken,
 	}
 
 	// Add namespace if provided

--- a/pkg/mcp/namespaces.go
+++ b/pkg/mcp/namespaces.go
@@ -3,6 +3,7 @@ package mcp
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"time"
 
 	"github.com/mark3labs/mcp-go/mcp"
@@ -15,6 +16,14 @@ func (s *Server) initNamespaces() []server.ServerTool {
 	ret = append(ret, server.ServerTool{
 		Tool: mcp.NewTool("namespaces_list",
 			mcp.WithDescription("List all the Kubernetes namespaces in the current cluster"),
+			mcp.WithNumber("limit",
+				mcp.DefaultNumber(10),
+				mcp.Description("Count of the resources that needs to be listed, this works in additional parameter called 'continue' which will have the value of continue token of paginated data."),
+				mcp.Required(),
+			),
+			mcp.WithNumber("continue",
+				mcp.Description("The continue token that received in previous call with limited count of resource items, this field works with additional field called 'limit'. "),
+			),
 		), Handler: s.namespacesList,
 	})
 	return ret
@@ -30,7 +39,20 @@ func (s *Server) namespacesList(ctx context.Context, ctr mcp.CallToolRequest) (*
 	sessionID := getSessionID(ctx)
 	klog.V(1).Infof("Tool: namespaces_list - listing all namespaces - got called by session id: %s", sessionID)
 
-	ret, err := k.NamespacesList(ctx)
+	limitStr, limitErr := ctr.RequireString("limit")
+	var limit int64 = 0
+	if limitErr == nil && limitStr != "" {
+		parsedLimit, parseErr := strconv.ParseInt(limitStr, 10, 64)
+		if parseErr == nil {
+			limit = parsedLimit
+		}
+	}
+	continueToken, continueErr := ctr.RequireString("continue")
+	if continueErr != nil {
+		continueToken = ""
+	}
+
+	ret, err := k.NamespacesList(ctx, limit, continueToken)
 	duration := time.Since(start)
 
 	if err != nil {

--- a/pkg/mcp/pods.go
+++ b/pkg/mcp/pods.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strconv"
 	"time"
 
 	"github.com/mark3labs/mcp-go/mcp"
@@ -27,13 +28,37 @@ func (s *Server) initPods() []server.ServerTool {
 	return []server.ServerTool{
 		{Tool: mcp.NewTool("pods_list",
 			mcp.WithDescription("List all the Kubernetes pods in the current cluster from all namespaces"),
+			mcp.WithNumber("limit",
+				mcp.DefaultNumber(10),
+				mcp.Description("Count of the resources that needs to be listed, this works in additional parameter called 'continue' which will have the value of continue token of paginated data."),
+				mcp.Required(),
+			),
+			mcp.WithNumber("continue",
+				mcp.Description("The continue token that received in previous call with limited count of resource items, this field works with additional field called 'limit'. "),
+			),
 		), Handler: s.podsListInAllNamespaces},
 		{Tool: mcp.NewTool("pods_list_in_namespace",
 			mcp.WithDescription("List all the Kubernetes pods in the specified namespace in the current cluster"),
+			mcp.WithNumber("limit",
+				mcp.DefaultNumber(10),
+				mcp.Description("Count of the resources that needs to be listed, this works in additional parameter called 'continue' which will have the value of continue token of paginated data."),
+				mcp.Required(),
+			),
+			mcp.WithNumber("continue",
+				mcp.Description("The continue token that received in previous call with limited count of resource items, this field works with additional field called 'limit'. "),
+			),
 			mcp.WithString("namespace", mcp.Description("Namespace to list pods from"), mcp.Required()),
 		), Handler: s.podsListInNamespace},
 		{Tool: mcp.NewTool("pods_get",
 			mcp.WithDescription("Get a Kubernetes Pod in the current or provided namespace with the provided name"),
+			mcp.WithNumber("limit",
+				mcp.DefaultNumber(10),
+				mcp.Description("Count of the resources that needs to be listed, this works in additional parameter called 'continue' which will have the value of continue token of paginated data."),
+				mcp.Required(),
+			),
+			mcp.WithNumber("continue",
+				mcp.Description("The continue token that received in previous call with limited count of resource items, this field works with additional field called 'limit'. "),
+			),
 			mcp.WithString("namespace", mcp.Description("Namespace to get the Pod from")),
 			mcp.WithString("name", mcp.Description("Name of the Pod"), mcp.Required()),
 		), Handler: s.podsGet},
@@ -86,7 +111,20 @@ func (s *Server) podsListInAllNamespaces(ctx context.Context, ctr mcp.CallToolRe
 		return NewTextResult("", fmt.Errorf("failed to initialize Kubernetes client: %v", err)), nil
 	}
 
-	ret, err := k.PodsListInAllNamespaces(ctx)
+	limitStr, limitErr := ctr.RequireString("limit")
+	var limit int64 = 0
+	if limitErr == nil && limitStr != "" {
+		parsedLimit, parseErr := strconv.ParseInt(limitStr, 10, 64)
+		if parseErr == nil {
+			limit = parsedLimit
+		}
+	}
+	continueToken, continueErr := ctr.RequireString("continue")
+	if continueErr != nil {
+		continueToken = ""
+	}
+
+	ret, err := k.PodsListInAllNamespaces(ctx, limit, continueToken)
 	duration := time.Since(start)
 
 	if err != nil {
@@ -118,7 +156,20 @@ func (s *Server) podsListInNamespace(ctx context.Context, ctr mcp.CallToolReques
 		return NewTextResult("", fmt.Errorf("failed to initialize Kubernetes client: %v", err)), nil
 	}
 
-	ret, err := k.PodsListInNamespace(ctx, ns)
+	limitStr, limitErr := ctr.RequireString("limit")
+	var limit int64 = 0
+	if limitErr == nil && limitStr != "" {
+		parsedLimit, parseErr := strconv.ParseInt(limitStr, 10, 64)
+		if parseErr == nil {
+			limit = parsedLimit
+		}
+	}
+	continueToken, continueErr := ctr.RequireString("continue")
+	if continueErr != nil {
+		continueToken = ""
+	}
+
+	ret, err := k.PodsListInNamespace(ctx, ns, limit, continueToken)
 	duration := time.Since(start)
 
 	if err != nil {

--- a/pkg/mcp/resources.go
+++ b/pkg/mcp/resources.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strconv"
 	"time"
 
 	"github.com/mark3labs/mcp-go/mcp"
@@ -27,6 +28,14 @@ func (s *Server) initResources() []server.ServerTool {
 			mcp.WithString("kind",
 				mcp.Description("kind of the resources (examples of valid kind are: Pod, Service, Deployment, Ingress)"),
 				mcp.Required(),
+			),
+			mcp.WithNumber("limit",
+				mcp.DefaultNumber(10),
+				mcp.Description("Count of the resources that needs to be listed, this works in additional parameter called 'continue' which will have the value of continue token of paginated data."),
+				mcp.Required(),
+			),
+			mcp.WithNumber("continue",
+				mcp.Description("The continue token that received in previous call with limited count of resource items, this field works with additional field called 'limit'. "),
 			),
 			mcp.WithString("namespace",
 				mcp.Description("Optional Namespace to retrieve the namespaced resources from (ignored in case of cluster scoped resources). If not provided, will list resources from all namespaces"))),
@@ -83,6 +92,14 @@ func (s *Server) initResources() []server.ServerTool {
 				mcp.Description("kind of the resource (examples of valid kind are: Pod, Service, Deployment, Ingress)"),
 				mcp.Required(),
 			),
+			mcp.WithNumber("limit",
+				mcp.DefaultNumber(10),
+				mcp.Description("Count of the resources that needs to be listed, this works in additional parameter called 'continue' which will have the value of continue token of paginated data."),
+				mcp.Required(),
+			),
+			mcp.WithNumber("continue",
+				mcp.Description("The continue token that received in previous call with limited count of resource items, this field works with additional field called 'limit'. "),
+			),
 			mcp.WithString("namespace",
 				mcp.Description("The namespace of the resource to get the definition for"),
 			),
@@ -137,6 +154,20 @@ func (s *Server) resourcesList(ctx context.Context, ctr mcp.CallToolRequest) (*m
 	if err != nil {
 		namespace = ""
 	}
+
+	limitStr, limitErr := ctr.RequireString("limit")
+	var limit int64 = 0
+	if limitErr == nil && limitStr != "" {
+		parsedLimit, parseErr := strconv.ParseInt(limitStr, 10, 64)
+		if parseErr == nil {
+			limit = parsedLimit
+		}
+	}
+	continueToken, continueErr := ctr.RequireString("continue")
+	if continueErr != nil {
+		continueToken = ""
+	}
+
 	gvk, err := parseGroupVersionKind(ctr.GetRawArguments().(map[string]interface{}))
 	if err != nil {
 		klog.Errorf("Tool call: resources_list failed after %v: %v", time.Since(start), err)
@@ -146,7 +177,7 @@ func (s *Server) resourcesList(ctx context.Context, ctr mcp.CallToolRequest) (*m
 	sessionID := getSessionID(ctx)
 	klog.V(1).Infof("Tool: resources_list - apiVersion: %s, kind: %s, namespace: %s - got called by session id: %s", gvk.Version, gvk.Kind, namespace, sessionID)
 
-	ret, err := k.ResourcesList(ctx, gvk, namespace)
+	ret, err := k.ResourcesList(ctx, gvk, namespace, limit, continueToken)
 	duration := time.Since(start)
 
 	if err != nil {
@@ -287,6 +318,20 @@ func (s *Server) resourcesYaml(ctx context.Context, ctr mcp.CallToolRequest) (*m
 	if err != nil {
 		namespace = ""
 	}
+
+	limitStr, limitErr := ctr.RequireString("limit")
+	var limit int64 = 0
+	if limitErr == nil && limitStr != "" {
+		parsedLimit, parseErr := strconv.ParseInt(limitStr, 10, 64)
+		if parseErr == nil {
+			limit = parsedLimit
+		}
+	}
+	continueToken, continueErr := ctr.RequireString("continue")
+	if continueErr != nil {
+		continueToken = ""
+	}
+
 	gvk, err := parseGroupVersionKind(ctr.GetRawArguments().(map[string]interface{}))
 	if err != nil {
 		klog.Errorf("Tool call: get_resources_yaml failed after %v: %v", time.Since(start), err)
@@ -310,7 +355,7 @@ func (s *Server) resourcesYaml(ctx context.Context, ctr mcp.CallToolRequest) (*m
 		return NewTextResult(ret, err), nil
 	} else {
 		// Get all resources of this type in the namespace
-		ret, err := k.ResourcesList(ctx, gvk, namespace)
+		ret, err := k.ResourcesList(ctx, gvk, namespace, limit, continueToken)
 		duration := time.Since(start)
 		if err != nil {
 			klog.Errorf("Tool call: get_resources_yaml failed after %v: %v", duration, err)


### PR DESCRIPTION
### Added pagination support to Kubernetes resource listing operations:

1. **Core Kubernetes functions** — Added limit and continueToken parameters to:
- NamespacesList
- PodsListInAllNamespaces
- PodsListInNamespace
- ResourcesList
2. **MCP handlers** — Updated handlers to parse and pass pagination parameters from MCP tool calls
3. **MCP tool definitions** — Added limit and continue parameters to:
- namespaces_list
- pods_list
- pods_list_in_namespace
- resources_list
- get_resources_yaml