### PR TITLE
feat: add MakeRequestWithHeaders method and update API response handling for Kubernetes resources

### DIFF
--- a/pkg/kubernetes/kubernetes.go
+++ b/pkg/kubernetes/kubernetes.go
@@ -80,6 +80,55 @@ func (h *HTTPClient) MakeRequest(method, endpoint string, body interface{}) ([]b
 	return responseBody, nil
 }
 
+// MakeRequestWithHeaders makes an HTTP request and returns both body and headers
+func (h *HTTPClient) MakeRequestWithHeaders(method, endpoint string, body interface{}) (*APIResponse, error) {
+	var reqBody io.Reader
+	var contentType string = "application/json"
+
+	if body != nil {
+		if rawBytes, ok := body.([]byte); ok {
+			reqBody = bytes.NewBuffer(rawBytes)
+			contentType = "application/yaml"
+		} else {
+			jsonBody, err := json.Marshal(body)
+			if err != nil {
+				return nil, fmt.Errorf("failed to marshal request body: %w", err)
+			}
+			reqBody = bytes.NewBuffer(jsonBody)
+		}
+	}
+
+	url := strings.TrimSuffix(h.BaseURL, "/") + "/" + strings.TrimPrefix(endpoint, "/")
+	req, err := http.NewRequest(method, url, reqBody)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	req.Header.Set("Authorization", "Bearer "+h.Token)
+	req.Header.Set("Content-Type", contentType)
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := h.Client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to make request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	responseBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response body: %w", err)
+	}
+
+	if resp.StatusCode >= 400 {
+		return nil, fmt.Errorf("API request failed with status %d: %s", resp.StatusCode, string(responseBody))
+	}
+
+	return &APIResponse{
+		Body:    responseBody,
+		Headers: resp.Header,
+	}, nil
+}
+
 type Kubernetes struct {
 	// HTTP Client for K8s Dashboard API
 	HTTPClient *HTTPClient
@@ -138,4 +187,15 @@ func namespaceOrDefault(namespace string) string {
 // MakeAPIRequest is a convenience method to make API requests to K8s Dashboard API
 func (k *Kubernetes) MakeAPIRequest(method, endpoint string, body interface{}) ([]byte, error) {
 	return k.HTTPClient.MakeRequest(method, endpoint, body)
+}
+
+// APIResponse contains both the response body and headers
+type APIResponse struct {
+	Body    []byte
+	Headers http.Header
+}
+
+// MakeAPIRequestWithHeaders makes an API request and returns both body and headers
+func (k *Kubernetes) MakeAPIRequestWithHeaders(method, endpoint string, body interface{}) (*APIResponse, error) {
+	return k.HTTPClient.MakeRequestWithHeaders(method, endpoint, body)
 }

--- a/pkg/kubernetes/namespaces.go
+++ b/pkg/kubernetes/namespaces.go
@@ -6,7 +6,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
-func (k *Kubernetes) NamespacesList(ctx context.Context, limit int64, continueToken string) (string, error) {
+func (k *Kubernetes) NamespacesList(ctx context.Context, limit int64, continueToken string) ([]byte, string, error) {
 	return k.ResourcesList(ctx, &schema.GroupVersionKind{
 		Group: "", Version: "v1", Kind: "Namespace",
 	}, "", limit, continueToken)

--- a/pkg/kubernetes/pods.go
+++ b/pkg/kubernetes/pods.go
@@ -9,13 +9,13 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
-func (k *Kubernetes) PodsListInAllNamespaces(ctx context.Context, limit int64, continueToken string) (string, error) {
+func (k *Kubernetes) PodsListInAllNamespaces(ctx context.Context, limit int64, continueToken string) ([]byte, string, error) {
 	return k.ResourcesList(ctx, &schema.GroupVersionKind{
 		Group: "", Version: "v1", Kind: "Pod",
 	}, "", limit, continueToken)
 }
 
-func (k *Kubernetes) PodsListInNamespace(ctx context.Context, namespace string, limit int64, continueToken string) (string, error) {
+func (k *Kubernetes) PodsListInNamespace(ctx context.Context, namespace string, limit int64, continueToken string) ([]byte, string, error) {
 	return k.ResourcesList(ctx, &schema.GroupVersionKind{
 		Group: "", Version: "v1", Kind: "Pod",
 	}, namespace, limit, continueToken)

--- a/pkg/kubernetes/resources.go
+++ b/pkg/kubernetes/resources.go
@@ -54,7 +54,7 @@ func getResourceTypeFromGVK(gvk *schema.GroupVersionKind) string {
 	return strings.ToLower(gvk.Kind) + "." + gvk.Group
 }
 
-func (k *Kubernetes) ResourcesList(ctx context.Context, gvk *schema.GroupVersionKind, namespace string, limit int64, continueToken string) (string, error) {
+func (k *Kubernetes) ResourcesList(ctx context.Context, gvk *schema.GroupVersionKind, namespace string, limit int64, continueToken string) ([]byte, string, error) {
 	// Create a JSON payload for the list-resources endpoint
 	requestBody := map[string]interface{}{
 		"apiVersion": gvk.GroupVersion().String(),
@@ -69,12 +69,16 @@ func (k *Kubernetes) ResourcesList(ctx context.Context, gvk *schema.GroupVersion
 	}
 
 	// Make API request to the dedicated MCP endpoint
-	response, err := k.MakeAPIRequest("POST", "/apis/v1/list-resources", requestBody)
+	apiResponse, err := k.MakeAPIRequestWithHeaders("POST", "/apis/v1/list-resources", requestBody)
 	if err != nil {
-		return "", fmt.Errorf("failed to list resources: %v", err)
+		fmt.Errorf("failed to list resources: %v", err)
+		return nil, "", err
 	}
 
-	return string(response), nil
+	data := apiResponse.Body
+	freshContinueToken := apiResponse.Headers.Get("x-continue-key")
+
+	return data, freshContinueToken, nil
 }
 
 func (k *Kubernetes) ResourcesGet(ctx context.Context, gvk *schema.GroupVersionKind, namespace, name string) (string, error) {

--- a/pkg/mcp/namespaces.go
+++ b/pkg/mcp/namespaces.go
@@ -2,6 +2,7 @@ package mcp
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"strconv"
 	"time"
@@ -52,7 +53,7 @@ func (s *Server) namespacesList(ctx context.Context, ctr mcp.CallToolRequest) (*
 		continueToken = ""
 	}
 
-	ret, err := k.NamespacesList(ctx, limit, continueToken)
+	ret, freshContinueToken, err := k.NamespacesList(ctx, limit, continueToken)
 	duration := time.Since(start)
 
 	if err != nil {
@@ -62,5 +63,21 @@ func (s *Server) namespacesList(ctx context.Context, ctr mcp.CallToolRequest) (*
 		klog.V(1).Infof("Tool call: namespaces_list completed successfully in %v by session id: %s", duration, sessionID)
 	}
 
-	return NewTextResult(ret, err), nil
+	// Compose response with results and continue token
+	response := struct {
+		Data          interface{} `json:"data"`
+		ContinueToken string      `json:"continueToken,omitempty"`
+	}{
+		Data:          ret,
+		ContinueToken: freshContinueToken,
+	}
+
+	// Marshal the response to JSON
+	jsonBytes, err := json.Marshal(response)
+	if err != nil {
+		klog.Errorf("Tool call: resources_list failed to marshal result to JSON after %v: %v", duration, err)
+		return NewTextResult("", fmt.Errorf("failed to marshal resource list: %v", err)), nil
+	}
+
+	return NewTextResult(string(jsonBytes), err), nil
 }

--- a/pkg/mcp/pods.go
+++ b/pkg/mcp/pods.go
@@ -2,6 +2,7 @@ package mcp
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"strconv"
@@ -124,7 +125,7 @@ func (s *Server) podsListInAllNamespaces(ctx context.Context, ctr mcp.CallToolRe
 		continueToken = ""
 	}
 
-	ret, err := k.PodsListInAllNamespaces(ctx, limit, continueToken)
+	ret, freshContinueToken, err := k.PodsListInAllNamespaces(ctx, limit, continueToken)
 	duration := time.Since(start)
 
 	if err != nil {
@@ -132,8 +133,24 @@ func (s *Server) podsListInAllNamespaces(ctx context.Context, ctr mcp.CallToolRe
 		return NewTextResult("", fmt.Errorf("failed to list pods in all namespaces: %v", err)), nil
 	}
 
+	// Compose response with results and continue token
+	response := struct {
+		Data          interface{} `json:"data"`
+		ContinueToken string      `json:"continueToken,omitempty"`
+	}{
+		Data:          ret,
+		ContinueToken: freshContinueToken,
+	}
+
+	// Marshal the response to JSON
+	jsonBytes, err := json.Marshal(response)
+	if err != nil {
+		klog.Errorf("Tool call: resources_list failed to marshal result to JSON after %v: %v", duration, err)
+		return NewTextResult("", fmt.Errorf("failed to marshal resource list: %v", err)), nil
+	}
+
 	klog.V(1).Infof("Tool call: pods_list completed successfully in %v by session id: %s", duration, sessionID)
-	return NewTextResult(ret, err), nil
+	return NewTextResult(string(jsonBytes), err), nil
 }
 
 func (s *Server) podsListInNamespace(ctx context.Context, ctr mcp.CallToolRequest) (*mcp.CallToolResult, error) {
@@ -169,7 +186,7 @@ func (s *Server) podsListInNamespace(ctx context.Context, ctr mcp.CallToolReques
 		continueToken = ""
 	}
 
-	ret, err := k.PodsListInNamespace(ctx, ns, limit, continueToken)
+	ret, freshContinueToken, err := k.PodsListInNamespace(ctx, ns, limit, continueToken)
 	duration := time.Since(start)
 
 	if err != nil {
@@ -177,8 +194,24 @@ func (s *Server) podsListInNamespace(ctx context.Context, ctr mcp.CallToolReques
 		return NewTextResult("", fmt.Errorf("failed to list pods in namespace %s: %v", ns, err)), nil
 	}
 
+	// Compose response with results and continue token
+	response := struct {
+		Data          interface{} `json:"data"`
+		ContinueToken string      `json:"continueToken,omitempty"`
+	}{
+		Data:          ret,
+		ContinueToken: freshContinueToken,
+	}
+
+	// Marshal the response to JSON
+	jsonBytes, err := json.Marshal(response)
+	if err != nil {
+		klog.Errorf("Tool call: resources_list failed to marshal result to JSON after %v: %v", duration, err)
+		return NewTextResult("", fmt.Errorf("failed to marshal resource list: %v", err)), nil
+	}
+
 	klog.V(1).Infof("Tool call: pods_list_in_namespace completed successfully in %v by session id: %s", duration, sessionID)
-	return NewTextResult(ret, err), nil
+	return NewTextResult(string(jsonBytes), err), nil
 }
 
 func (s *Server) podsGet(ctx context.Context, ctr mcp.CallToolRequest) (*mcp.CallToolResult, error) {

--- a/pkg/mcp/resources.go
+++ b/pkg/mcp/resources.go
@@ -177,7 +177,7 @@ func (s *Server) resourcesList(ctx context.Context, ctr mcp.CallToolRequest) (*m
 	sessionID := getSessionID(ctx)
 	klog.V(1).Infof("Tool: resources_list - apiVersion: %s, kind: %s, namespace: %s - got called by session id: %s", gvk.Version, gvk.Kind, namespace, sessionID)
 
-	ret, err := k.ResourcesList(ctx, gvk, namespace, limit, continueToken)
+	ret, freshContinueToken, err := k.ResourcesList(ctx, gvk, namespace, limit, continueToken)
 	duration := time.Since(start)
 
 	if err != nil {
@@ -185,8 +185,24 @@ func (s *Server) resourcesList(ctx context.Context, ctr mcp.CallToolRequest) (*m
 		return NewTextResult("", fmt.Errorf("failed to list resources: %v", err)), nil
 	}
 
+	// Compose response with results and continue token
+	response := struct {
+		Data          interface{} `json:"data"`
+		ContinueToken string      `json:"continueToken,omitempty"`
+	}{
+		Data:          ret,
+		ContinueToken: freshContinueToken,
+	}
+
+	// Marshal the response to JSON
+	jsonBytes, err := json.Marshal(response)
+	if err != nil {
+		klog.Errorf("Tool call: resources_list failed to marshal result to JSON after %v: %v", duration, err)
+		return NewTextResult("", fmt.Errorf("failed to marshal resource list: %v", err)), nil
+	}
+
 	klog.V(1).Infof("Tool call: resources_list completed successfully in %v by session id: %s", duration, sessionID)
-	return NewTextResult(ret, err), nil
+	return NewTextResult(string(jsonBytes), nil), nil
 }
 
 func (s *Server) resourcesGet(ctx context.Context, ctr mcp.CallToolRequest) (*mcp.CallToolResult, error) {
@@ -355,14 +371,31 @@ func (s *Server) resourcesYaml(ctx context.Context, ctr mcp.CallToolRequest) (*m
 		return NewTextResult(ret, err), nil
 	} else {
 		// Get all resources of this type in the namespace
-		ret, err := k.ResourcesList(ctx, gvk, namespace, limit, continueToken)
+		ret, freshContinueToken, err := k.ResourcesList(ctx, gvk, namespace, limit, continueToken)
 		duration := time.Since(start)
 		if err != nil {
 			klog.Errorf("Tool call: get_resources_yaml failed after %v: %v", duration, err)
 			return NewTextResult("", fmt.Errorf("failed to list resources YAML: %v", err)), nil
 		}
+
+		// Compose response with results and continue token
+		response := struct {
+			Data          interface{} `json:"data"`
+			ContinueToken string      `json:"continueToken,omitempty"`
+		}{
+			Data:          ret,
+			ContinueToken: freshContinueToken,
+		}
+
+		// Marshal the response to JSON
+		jsonBytes, err := json.Marshal(response)
+		if err != nil {
+			klog.Errorf("Tool call: resources_list failed to marshal result to JSON after %v: %v", duration, err)
+			return NewTextResult("", fmt.Errorf("failed to marshal resource list: %v", err)), nil
+		}
+
 		klog.V(1).Infof("Tool call: get_resources_yaml completed successfully in %v by session id: %s", duration, sessionID)
-		return NewTextResult(ret, err), nil
+		return NewTextResult(string(jsonBytes), err), nil
 	}
 }
 


### PR DESCRIPTION

- Introduced MakeRequestWithHeaders to handle HTTP requests with headers and return both body and headers.
- Updated existing resource listing methods to return byte arrays and continue tokens for better pagination support.
- Enhanced namespaces and pods listing functions to align with new response structure.
- Adjusted MCP server methods to accommodate changes in resource listing and response formatting.