### PR TITLE
refactor: update resource listing methods to return remaining item count

### DIFF
--- a/pkg/kubernetes/namespaces.go
+++ b/pkg/kubernetes/namespaces.go
@@ -6,7 +6,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
-func (k *Kubernetes) NamespacesList(ctx context.Context, limit int64, continueToken string) ([]byte, string, error) {
+func (k *Kubernetes) NamespacesList(ctx context.Context, limit int64, continueToken string) ([]byte, string, int64, error) {
 	return k.ResourcesList(ctx, &schema.GroupVersionKind{
 		Group: "", Version: "v1", Kind: "Namespace",
 	}, "", limit, continueToken)

--- a/pkg/kubernetes/pods.go
+++ b/pkg/kubernetes/pods.go
@@ -9,13 +9,13 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
-func (k *Kubernetes) PodsListInAllNamespaces(ctx context.Context, limit int64, continueToken string) ([]byte, string, error) {
+func (k *Kubernetes) PodsListInAllNamespaces(ctx context.Context, limit int64, continueToken string) ([]byte, string, int64, error) {
 	return k.ResourcesList(ctx, &schema.GroupVersionKind{
 		Group: "", Version: "v1", Kind: "Pod",
 	}, "", limit, continueToken)
 }
 
-func (k *Kubernetes) PodsListInNamespace(ctx context.Context, namespace string, limit int64, continueToken string) ([]byte, string, error) {
+func (k *Kubernetes) PodsListInNamespace(ctx context.Context, namespace string, limit int64, continueToken string) ([]byte, string, int64, error) {
 	return k.ResourcesList(ctx, &schema.GroupVersionKind{
 		Group: "", Version: "v1", Kind: "Pod",
 	}, namespace, limit, continueToken)

--- a/pkg/kubernetes/resources.go
+++ b/pkg/kubernetes/resources.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strconv"
 	"strings"
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -54,7 +55,7 @@ func getResourceTypeFromGVK(gvk *schema.GroupVersionKind) string {
 	return strings.ToLower(gvk.Kind) + "." + gvk.Group
 }
 
-func (k *Kubernetes) ResourcesList(ctx context.Context, gvk *schema.GroupVersionKind, namespace string, limit int64, continueToken string) ([]byte, string, error) {
+func (k *Kubernetes) ResourcesList(ctx context.Context, gvk *schema.GroupVersionKind, namespace string, limit int64, continueToken string) ([]byte, string, int64, error) {
 	// Create a JSON payload for the list-resources endpoint
 	requestBody := map[string]interface{}{
 		"apiVersion": gvk.GroupVersion().String(),
@@ -72,13 +73,18 @@ func (k *Kubernetes) ResourcesList(ctx context.Context, gvk *schema.GroupVersion
 	apiResponse, err := k.MakeAPIRequestWithHeaders("POST", "/apis/v1/list-resources", requestBody)
 	if err != nil {
 		fmt.Errorf("failed to list resources: %v", err)
-		return nil, "", err
+		return nil, "", 0, err
 	}
 
 	data := apiResponse.Body
 	freshContinueToken := apiResponse.Headers.Get("x-continue-key")
+	remainingItemCount, err := strconv.ParseInt(apiResponse.Headers.Get("x-remaining-items"), 10, 64)
+	if err != nil {
+		fmt.Errorf("failed to list resources: %v", err)
+		return nil, "", 0, err
+	}
 
-	return data, freshContinueToken, nil
+	return data, freshContinueToken, remainingItemCount, nil
 }
 
 func (k *Kubernetes) ResourcesGet(ctx context.Context, gvk *schema.GroupVersionKind, namespace, name string) (string, error) {

--- a/pkg/mcp/namespaces.go
+++ b/pkg/mcp/namespaces.go
@@ -18,8 +18,7 @@ func (s *Server) initNamespaces() []server.ServerTool {
 			mcp.WithDescription("List all the Kubernetes namespaces in the current cluster"),
 			mcp.WithNumber("limit",
 				mcp.DefaultNumber(5),
-				mcp.Max(5),
-				mcp.Description("Count of the resources that needs to be listed (max value=5), this works in additional parameter called 'continue' which will have the value of continue token of paginated data."),
+				mcp.Description("Count of the resources that needs to be listed, this works in additional parameter called 'continue' which will have the value of continue token of paginated data."),
 				mcp.Required(),
 			),
 			mcp.WithString("continue",
@@ -44,7 +43,7 @@ func (s *Server) namespacesList(ctx context.Context, ctr mcp.CallToolRequest) (*
 
 	continueToken := ctr.GetString("continue", "")
 
-	ret, freshContinueToken, err := k.NamespacesList(ctx, int64(limit), continueToken)
+	ret, freshContinueToken, remainingCount, err := k.NamespacesList(ctx, int64(limit), continueToken)
 	duration := time.Since(start)
 
 	if err != nil {
@@ -60,12 +59,10 @@ func (s *Server) namespacesList(ctx context.Context, ctr mcp.CallToolRequest) (*
 		return NewTextResult("", fmt.Errorf("failed to unmarshal namespace list: %v", err)), nil
 	}
 
-	response := struct {
-		Data          interface{} `json:"data"`
-		ContinueToken string      `json:"continueToken,omitempty"`
-	}{
-		Data:          data,
-		ContinueToken: freshContinueToken,
+	response := ListResourceToolOutput{
+		Data:                data,
+		ContinueToken:       freshContinueToken,
+		RemainingItemsCount: remainingCount,
 	}
 
 	jsonBytes, err := json.Marshal(response)

--- a/pkg/mcp/pods.go
+++ b/pkg/mcp/pods.go
@@ -25,8 +25,9 @@ import (
 // }
 
 type ListResourceToolOutput struct {
-	Data          interface{} `json:"data"`
-	ContinueToken string      `json:"continueToken,omitempty"`
+	Data                interface{} `json:"data"`
+	ContinueToken       string      `json:"continueToken,omitempty"`
+	RemainingItemsCount int64       `json:"remainingItemsCount,omitempty"`
 }
 
 func (s *Server) initPods() []server.ServerTool {
@@ -35,8 +36,7 @@ func (s *Server) initPods() []server.ServerTool {
 			mcp.WithDescription("List all the Kubernetes pods in the current cluster from all namespaces"),
 			mcp.WithNumber("limit",
 				mcp.DefaultNumber(5),
-				mcp.Max(5),
-				mcp.Description("Count of the resources that needs to be listed (max value=5), this works in additional parameter called 'continue' which will have the value of continue token of paginated data."),
+				mcp.Description("Count of the resources that needs to be listed, this works in additional parameter called 'continue' which will have the value of continue token of paginated data."),
 				mcp.Required(),
 			),
 			mcp.WithString("continue",
@@ -47,8 +47,7 @@ func (s *Server) initPods() []server.ServerTool {
 			mcp.WithDescription("List all the Kubernetes pods in the specified namespace in the current cluster"),
 			mcp.WithNumber("limit",
 				mcp.DefaultNumber(5),
-				mcp.Max(5),
-				mcp.Description("Count of the resources that needs to be listed (max value=5), this works in additional parameter called 'continue' which will have the value of continue token of paginated data."),
+				mcp.Description("Count of the resources that needs to be listed, this works in additional parameter called 'continue' which will have the value of continue token of paginated data."),
 				mcp.Required(),
 			),
 			mcp.WithString("continue",
@@ -60,8 +59,7 @@ func (s *Server) initPods() []server.ServerTool {
 			mcp.WithDescription("Get a Kubernetes Pod in the current or provided namespace with the provided name"),
 			mcp.WithNumber("limit",
 				mcp.DefaultNumber(5),
-				mcp.Max(5),
-				mcp.Description("Count of the resources that needs to be listed (max value=5), this works in additional parameter called 'continue' which will have the value of continue token of paginated data."),
+				mcp.Description("Count of the resources that needs to be listed, this works in additional parameter called 'continue' which will have the value of continue token of paginated data."),
 				mcp.Required(),
 			),
 			mcp.WithString("continue",
@@ -124,7 +122,7 @@ func (s *Server) podsListInAllNamespaces(ctx context.Context, ctr mcp.CallToolRe
 	continueToken := ctr.GetString("continue", "")
 
 	klog.V(1).Infof("Limit number %v", limit)
-	ret, freshContinueToken, err := k.PodsListInAllNamespaces(ctx, int64(limit), continueToken)
+	ret, freshContinueToken, remainingCount, err := k.PodsListInAllNamespaces(ctx, int64(limit), continueToken)
 	duration := time.Since(start)
 
 	if err != nil {
@@ -139,8 +137,9 @@ func (s *Server) podsListInAllNamespaces(ctx context.Context, ctr mcp.CallToolRe
 	}
 
 	response := ListResourceToolOutput{
-		Data:          data,
-		ContinueToken: freshContinueToken,
+		Data:                data,
+		ContinueToken:       freshContinueToken,
+		RemainingItemsCount: remainingCount,
 	}
 
 	jsonBytes, err := json.Marshal(response)
@@ -179,7 +178,7 @@ func (s *Server) podsListInNamespace(ctx context.Context, ctr mcp.CallToolReques
 
 	continueToken := ctr.GetString("continue", "")
 
-	ret, freshContinueToken, err := k.PodsListInNamespace(ctx, ns, int64(limit), continueToken)
+	ret, freshContinueToken, remainingCount, err := k.PodsListInNamespace(ctx, ns, int64(limit), continueToken)
 	duration := time.Since(start)
 
 	if err != nil {
@@ -193,12 +192,10 @@ func (s *Server) podsListInNamespace(ctx context.Context, ctr mcp.CallToolReques
 		return NewTextResult("", fmt.Errorf("failed to unmarshal pod list: %v", err)), nil
 	}
 
-	response := struct {
-		Data          interface{} `json:"data"`
-		ContinueToken string      `json:"continueToken,omitempty"`
-	}{
-		Data:          data,
-		ContinueToken: freshContinueToken,
+	response := ListResourceToolOutput{
+		Data:                data,
+		ContinueToken:       freshContinueToken,
+		RemainingItemsCount: remainingCount,
 	}
 
 	jsonBytes, err := json.Marshal(response)

--- a/pkg/mcp/resources.go
+++ b/pkg/mcp/resources.go
@@ -30,8 +30,7 @@ func (s *Server) initResources() []server.ServerTool {
 			),
 			mcp.WithNumber("limit",
 				mcp.DefaultNumber(5),
-				mcp.Max(5),
-				mcp.Description("Count of the resources that needs to be listed (max value=5), this works in additional parameter called 'continue' which will have the value of continue token of paginated data."),
+				mcp.Description("Count of the resources that needs to be listed, this works in additional parameter called 'continue' which will have the value of continue token of paginated data."),
 				mcp.Required()),
 			mcp.WithString("continue",
 				mcp.Description("The continue token that received in previous call with limited count of resource items, this field works with additional field called 'limit'. "),
@@ -93,8 +92,7 @@ func (s *Server) initResources() []server.ServerTool {
 			),
 			mcp.WithNumber("limit",
 				mcp.DefaultNumber(5),
-				mcp.Max(5),
-				mcp.Description("Count of the resources that needs to be listed (max value=5), this works in additional parameter called 'continue' which will have the value of continue token of paginated data."),
+				mcp.Description("Count of the resources that needs to be listed, this works in additional parameter called 'continue' which will have the value of continue token of paginated data."),
 				mcp.Required()),
 			mcp.WithString("continue",
 				mcp.Description("The continue token that received in previous call with limited count of resource items, this field works with additional field called 'limit'. "),
@@ -167,7 +165,7 @@ func (s *Server) resourcesList(ctx context.Context, ctr mcp.CallToolRequest) (*m
 	sessionID := getSessionID(ctx)
 	klog.V(1).Infof("Tool: resources_list - apiVersion: %s, kind: %s, namespace: %s - got called by session id: %s", gvk.Version, gvk.Kind, namespace, sessionID)
 
-	ret, freshContinueToken, err := k.ResourcesList(ctx, gvk, namespace, int64(limit), continueToken)
+	ret, freshContinueToken, remainingCount, err := k.ResourcesList(ctx, gvk, namespace, int64(limit), continueToken)
 	duration := time.Since(start)
 
 	if err != nil {
@@ -181,12 +179,10 @@ func (s *Server) resourcesList(ctx context.Context, ctr mcp.CallToolRequest) (*m
 		return NewTextResult("", fmt.Errorf("failed to unmarshal resource list: %v", err)), nil
 	}
 
-	response := struct {
-		Data          interface{} `json:"data"`
-		ContinueToken string      `json:"continueToken,omitempty"`
-	}{
-		Data:          data,
-		ContinueToken: freshContinueToken,
+	response := ListResourceToolOutput{
+		Data:                data,
+		ContinueToken:       freshContinueToken,
+		RemainingItemsCount: remainingCount,
 	}
 
 	jsonBytes, err := json.Marshal(response)
@@ -356,7 +352,7 @@ func (s *Server) resourcesYaml(ctx context.Context, ctr mcp.CallToolRequest) (*m
 		return NewTextResult(ret, err), nil
 	} else {
 		// Get all resources of this type in the namespace
-		ret, freshContinueToken, err := k.ResourcesList(ctx, gvk, namespace, int64(limit), continueToken)
+		ret, freshContinueToken, remainingCount, err := k.ResourcesList(ctx, gvk, namespace, int64(limit), continueToken)
 		duration := time.Since(start)
 		if err != nil {
 			klog.Errorf("Tool call: get_resources_yaml failed after %v: %v", duration, err)
@@ -369,12 +365,10 @@ func (s *Server) resourcesYaml(ctx context.Context, ctr mcp.CallToolRequest) (*m
 			return NewTextResult("", fmt.Errorf("failed to unmarshal resource list: %v", err)), nil
 		}
 
-		response := struct {
-			Data          interface{} `json:"data"`
-			ContinueToken string      `json:"continueToken,omitempty"`
-		}{
-			Data:          data,
-			ContinueToken: freshContinueToken,
+		response := ListResourceToolOutput{
+			Data:                data,
+			ContinueToken:       freshContinueToken,
+			RemainingItemsCount: remainingCount,
 		}
 
 		jsonBytes, err := json.Marshal(response)


### PR DESCRIPTION
- Modified the return types of NamespacesList, PodsListInAllNamespaces, and PodsListInNamespace methods to include remaining item count for better pagination support.
- Updated ResourcesList method to parse and return the remaining items count from API response headers.
- Adjusted MCP server methods to handle the new response structure, ensuring consistent output across resource listing functionalities.