### PR TITLE
refactor: remove deprecated pod and node listing methods, enhance resource listing with view parameter

### DIFF
--- a/pkg/llm/prompt_generator.go
+++ b/pkg/llm/prompt_generator.go
@@ -25,19 +25,15 @@ Below is the list of available Kubernetes tools that can be included in your pro
 ### Cluster Information Tools
 - configuration_view (Get Kubernetes configuration)
 - get_available_API_resources (Get all available API resources)
-- get_resources_yaml (Get YAML representation of resources)
 - namespaces_list (List all namespaces)
 - events_list (List Kubernetes events)
 
 ### Node Tools
 - nodes_get (Get detailed node information)
-- nodes_list (List all nodes)
 - nodes_metrics (Get node metrics)
 
 ### Pod Tools
 - pods_get (Get pod details)
-- pods_list (List all pods)
-- pods_list_in_namespace (List pods in namespace)
 - pods_log (Get pod logs)
 - pods_delete (Delete a pod)
 - pods_exec (Execute commands in pod)
@@ -48,7 +44,7 @@ Below is the list of available Kubernetes tools that can be included in your pro
 - resources_create_or_update (Create/update resources)
 - resources_delete (Delete resources)
 - resources_get (Get specific resource)
-- resources_list (List resources)
+- resources_list (List resources with optional view parameter: 'json' or 'yaml')
 - resources_patch (Patch resources)
 - apply_manifest (Apply YAML manifest)
 - rollout (Manage deployments rollout)

--- a/pkg/mcp/nodes.go
+++ b/pkg/mcp/nodes.go
@@ -13,37 +13,11 @@ import (
 
 func (s *Server) initNodes() []server.ServerTool {
 	return []server.ServerTool{
-		{Tool: mcp.NewTool("nodes_list",
-			mcp.WithDescription("List all Kubernetes nodes in the current cluster"),
-		), Handler: s.nodesList},
 		{Tool: mcp.NewTool("nodes_get",
 			mcp.WithDescription("Get detailed information about a specific Kubernetes node"),
 			mcp.WithString("name", mcp.Description("Name of the node"), mcp.Required()),
 		), Handler: s.nodesGet},
 	}
-}
-
-// nodesList handles the nodes_list tool request
-func (s *Server) nodesList(ctx context.Context, ctr mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	start := time.Now()
-	k, err := s.getKubernetesClient(ctr)
-	if err != nil {
-		klog.Errorf("Tool call: nodes_list failed to get Kubernetes client after %v: %v", time.Since(start), err)
-		return NewTextResult("", fmt.Errorf("failed to initialize Kubernetes client: %v", err)), nil
-	}
-	sessionID := getSessionID(ctx)
-	klog.V(1).Infof("Tool: nodes_list - listing all nodes - got called by session id: %s", sessionID)
-
-	ret, err := k.NodesList(ctx)
-	duration := time.Since(start)
-
-	if err != nil {
-		klog.Errorf("Tool call: nodes_list failed after %v: %v by session id: %s", duration, err, sessionID)
-		return NewTextResult("", fmt.Errorf("failed to list nodes: %v", err)), nil
-	}
-
-	klog.V(1).Infof("Tool call: nodes_list completed successfully in %v by session id: %s", duration, sessionID)
-	return NewTextResult(ret, nil), nil
 }
 
 // nodesGet handles the nodes_get tool request

--- a/pkg/mcp/pods.go
+++ b/pkg/mcp/pods.go
@@ -2,7 +2,6 @@ package mcp
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"time"
@@ -17,7 +16,7 @@ import (
 //
 // Example usage:
 // {
-//   "name": "pods_list",
+//   "name": "pods_get",
 //   "arguments": {
 //     "k8surl": "https://your-k8s-api-server:6443",
 //     "k8stoken": "your-auth-token"
@@ -32,29 +31,6 @@ type ListResourceToolOutput struct {
 
 func (s *Server) initPods() []server.ServerTool {
 	return []server.ServerTool{
-		{Tool: mcp.NewTool("pods_list",
-			mcp.WithDescription("List all the Kubernetes pods in the current cluster from all namespaces"),
-			mcp.WithNumber("limit",
-				mcp.DefaultNumber(5),
-				mcp.Description("Count of the resources that needs to be listed, this works in additional parameter called 'continue' which will have the value of continue token of paginated data."),
-				mcp.Required(),
-			),
-			mcp.WithString("continue",
-				mcp.Description("The continue token that received in previous call with limited count of resource items, this field works with additional field called 'limit'. "),
-			),
-		), Handler: s.podsListInAllNamespaces},
-		{Tool: mcp.NewTool("pods_list_in_namespace",
-			mcp.WithDescription("List all the Kubernetes pods in the specified namespace in the current cluster"),
-			mcp.WithNumber("limit",
-				mcp.DefaultNumber(5),
-				mcp.Description("Count of the resources that needs to be listed, this works in additional parameter called 'continue' which will have the value of continue token of paginated data."),
-				mcp.Required(),
-			),
-			mcp.WithString("continue",
-				mcp.Description("The continue token that received in previous call with limited count of resource items, this field works with additional field called 'limit'. "),
-			),
-			mcp.WithString("namespace", mcp.Description("Namespace to list pods from"), mcp.Required()),
-		), Handler: s.podsListInNamespace},
 		{Tool: mcp.NewTool("pods_get",
 			mcp.WithDescription("Get a Kubernetes Pod in the current or provided namespace with the provided name"),
 			mcp.WithNumber("limit",
@@ -103,109 +79,6 @@ func (s *Server) initPods() []server.ServerTool {
 			mcp.WithNumber("port", mcp.Description("TCP/IP port to expose from the Pod container (Optional, no port exposed if not provided)")),
 		), Handler: s.podsRun},
 	}
-}
-
-func (s *Server) podsListInAllNamespaces(ctx context.Context, ctr mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	start := time.Now()
-	sessionID := getSessionID(ctx)
-	klog.V(1).Infof("Tool: pods_list - listing all pods in all namespaces - got called by session id: %s", sessionID)
-
-	// Get Kubernetes client from request parameters
-	k, err := s.getKubernetesClient(ctr)
-	if err != nil {
-		klog.Errorf("Tool call: pods_list failed to get Kubernetes client after %v: %v", time.Since(start), err)
-		return NewTextResult("", fmt.Errorf("failed to initialize Kubernetes client: %v", err)), nil
-	}
-
-	limit := ctr.GetInt("limit", 10)
-
-	continueToken := ctr.GetString("continue", "")
-
-	klog.V(1).Infof("Limit number %v", limit)
-	ret, freshContinueToken, remainingCount, err := k.PodsListInAllNamespaces(ctx, int64(limit), continueToken)
-	duration := time.Since(start)
-
-	if err != nil {
-		klog.Errorf("Tool call: pods_list failed after %v: %v", duration, err)
-		return NewTextResult("", fmt.Errorf("failed to list pods in all namespaces: %v", err)), nil
-	}
-
-	var data interface{}
-	if err := json.Unmarshal(ret, &data); err != nil {
-		klog.Errorf("Tool call: pods_list failed to unmarshal response after %v: %v", duration, err)
-		return NewTextResult("", fmt.Errorf("failed to unmarshal pod list: %v", err)), nil
-	}
-
-	response := ListResourceToolOutput{
-		Data:                data,
-		ContinueToken:       freshContinueToken,
-		RemainingItemsCount: remainingCount,
-	}
-
-	jsonBytes, err := json.Marshal(response)
-	if err != nil {
-		klog.Errorf("Tool call: resources_list failed to marshal result to JSON after %v: %v", duration, err)
-		return NewTextResult("", fmt.Errorf("failed to marshal resource list: %v", err)), nil
-	}
-
-	jsonString := string(jsonBytes)
-
-	klog.V(1).Infof("Tool call: pods_list completed successfully in %v by session id: %s", duration, sessionID)
-	return NewTextResult(jsonString, err), nil
-}
-
-func (s *Server) podsListInNamespace(ctx context.Context, ctr mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	start := time.Now()
-	ns := ctr.GetString("namespace", "")
-
-	sessionID := getSessionID(ctx)
-
-	klog.V(1).Infof("Tool: pods_list_in_namespace - listing all pods in namespace: %s - got called by session id: %s", ns, sessionID)
-
-	if ns == "" {
-		klog.Errorf("Tool call: pods_list_in_namespace failed after %v: missing namespace parameter", time.Since(start))
-		return NewTextResult("", errors.New("failed to list pods in namespace, missing argument namespace")), nil
-	}
-
-	// Get Kubernetes client from request parameters
-	k, err := s.getKubernetesClient(ctr)
-	if err != nil {
-		klog.Errorf("Tool call: pods_list_in_namespace failed to get Kubernetes client after %v: %v", time.Since(start), err)
-		return NewTextResult("", fmt.Errorf("failed to initialize Kubernetes client: %v", err)), nil
-	}
-
-	limit := ctr.GetInt("limit", 10)
-
-	continueToken := ctr.GetString("continue", "")
-
-	ret, freshContinueToken, remainingCount, err := k.PodsListInNamespace(ctx, ns, int64(limit), continueToken)
-	duration := time.Since(start)
-
-	if err != nil {
-		klog.Errorf("Tool call: pods_list_in_namespace failed after %v: %v", duration, err)
-		return NewTextResult("", fmt.Errorf("failed to list pods in namespace %s: %v", ns, err)), nil
-	}
-
-	var data interface{}
-	if err := json.Unmarshal(ret, &data); err != nil {
-		klog.Errorf("Tool call: pods_list_in_namespace failed to unmarshal response after %v: %v", duration, err)
-		return NewTextResult("", fmt.Errorf("failed to unmarshal pod list: %v", err)), nil
-	}
-
-	response := ListResourceToolOutput{
-		Data:                data,
-		ContinueToken:       freshContinueToken,
-		RemainingItemsCount: remainingCount,
-	}
-
-	jsonBytes, err := json.Marshal(response)
-	if err != nil {
-		klog.Errorf("Tool call: resources_list failed to marshal result to JSON after %v: %v", duration, err)
-		return NewTextResult("", fmt.Errorf("failed to marshal resource list: %v", err)), nil
-	}
-
-	klog.V(1).Infof("Tool call: pods_list_in_namespace completed successfully in %v by session id: %s", duration, sessionID)
-	return mcp.NewToolResultStructured(jsonBytes, ""), nil
 }
 
 func (s *Server) podsGet(ctx context.Context, ctr mcp.CallToolRequest) (*mcp.CallToolResult, error) {

--- a/pkg/mcp/resources.go
+++ b/pkg/mcp/resources.go
@@ -11,6 +11,7 @@ import (
 	"github.com/mark3labs/mcp-go/server"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/klog/v2"
+	"sigs.k8s.io/yaml"
 )
 
 func (s *Server) initResources() []server.ServerTool {
@@ -36,9 +37,10 @@ func (s *Server) initResources() []server.ServerTool {
 				mcp.Description("The continue token that received in previous call with limited count of resource items, this field works with additional field called 'limit'. "),
 			),
 			mcp.WithString("namespace",
-				mcp.Description("Optional Namespace to retrieve the namespaced resources from (ignored in case of cluster scoped resources). If not provided, will list resources from all namespaces"))),
-			Handler: s.resourcesList,
-		},
+				mcp.Description("Optional Namespace to retrieve the namespaced resources from (ignored in case of cluster scoped resources). If not provided, will list resources from all namespaces")),
+			mcp.WithString("view",
+				mcp.Description("Output format: 'json' (default) or 'yaml'. When 'yaml' is specified, the response will be in YAML format instead of JSON.")),
+		), Handler: s.resourcesList},
 		{Tool: mcp.NewTool("resources_get",
 			mcp.WithDescription("Get a Kubernetes resource in the current cluster by providing its apiVersion, kind, optionally the namespace, and its name\n"+
 				commonApiVersion),
@@ -79,29 +81,6 @@ func (s *Server) initResources() []server.ServerTool {
 			),
 			mcp.WithString("name", mcp.Description("Name of the resource"), mcp.Required()),
 		), Handler: s.resourcesDelete},
-		{Tool: mcp.NewTool("get_resources_yaml",
-			mcp.WithDescription("Get the YAML representation of a resource in Kubernetes\n"+
-				commonApiVersion),
-			mcp.WithString("apiVersion",
-				mcp.Description("apiVersion of the resource (examples of valid apiVersion are: v1, apps/v1, networking.k8s.io/v1)"),
-				mcp.Required(),
-			),
-			mcp.WithString("kind",
-				mcp.Description("kind of the resource (examples of valid kind are: Pod, Service, Deployment, Ingress)"),
-				mcp.Required(),
-			),
-			mcp.WithNumber("limit",
-				mcp.DefaultNumber(5),
-				mcp.Description("Count of the resources that needs to be listed, this works in additional parameter called 'continue' which will have the value of continue token of paginated data."),
-				mcp.Required()),
-			mcp.WithString("continue",
-				mcp.Description("The continue token that received in previous call with limited count of resource items, this field works with additional field called 'limit'. "),
-			),
-			mcp.WithString("namespace",
-				mcp.Description("The namespace of the resource to get the definition for"),
-			),
-			mcp.WithString("name", mcp.Description("The name of the resource to get the YAML definition for. If not provided, all resources of the given type will be returned")),
-		), Handler: s.resourcesYaml},
 		// {Tool: mcp.NewTool("apply_manifest",
 		// 	mcp.WithDescription("Apply a YAML resource file to the Kubernetes cluster"),
 		// 	mcp.WithString("manifest_path",
@@ -155,6 +134,7 @@ func (s *Server) resourcesList(ctx context.Context, ctr mcp.CallToolRequest) (*m
 	limit := ctr.GetInt("limit", 10)
 
 	continueToken := ctr.GetString("continue", "")
+	view := ctr.GetString("view", "json")
 
 	gvk, err := parseGroupVersionKind(ctr.GetRawArguments().(map[string]interface{}))
 	if err != nil {
@@ -163,7 +143,7 @@ func (s *Server) resourcesList(ctx context.Context, ctr mcp.CallToolRequest) (*m
 	}
 
 	sessionID := getSessionID(ctx)
-	klog.V(1).Infof("Tool: resources_list - apiVersion: %s, kind: %s, namespace: %s - got called by session id: %s", gvk.Version, gvk.Kind, namespace, sessionID)
+	klog.V(1).Infof("Tool: resources_list - apiVersion: %s, kind: %s, namespace: %s, view: %s - got called by session id: %s", gvk.Version, gvk.Kind, namespace, view, sessionID)
 
 	ret, freshContinueToken, remainingCount, err := k.ResourcesList(ctx, gvk, namespace, int64(limit), continueToken)
 	duration := time.Since(start)
@@ -183,6 +163,16 @@ func (s *Server) resourcesList(ctx context.Context, ctr mcp.CallToolRequest) (*m
 		Data:                data,
 		ContinueToken:       freshContinueToken,
 		RemainingItemsCount: remainingCount,
+	}
+
+	if view == "yaml" {
+		yamlBytes, err := yaml.Marshal(response)
+		if err != nil {
+			klog.Errorf("Tool call: resources_list failed to marshal result to YAML after %v: %v", duration, err)
+			return NewTextResult("", fmt.Errorf("failed to marshal resource list to YAML: %v", err)), nil
+		}
+		klog.V(1).Infof("Tool call: resources_list completed successfully in %v by session id: %s", duration, sessionID)
+		return NewTextResult(string(yamlBytes), nil), nil
 	}
 
 	jsonBytes, err := json.Marshal(response)
@@ -311,75 +301,6 @@ func parseGroupVersionKind(arguments map[string]interface{}) (*schema.GroupVersi
 		return nil, errors.New("invalid argument apiVersion")
 	}
 	return &schema.GroupVersionKind{Group: gv.Group, Version: gv.Version, Kind: kind.(string)}, nil
-}
-
-func (s *Server) resourcesYaml(ctx context.Context, ctr mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	start := time.Now()
-	k, err := s.getKubernetesClient(ctr)
-	if err != nil {
-		klog.Errorf("Tool call: get_resources_yaml failed to get Kubernetes client after %v: %v", time.Since(start), err)
-		return NewTextResult("", fmt.Errorf("failed to initialize Kubernetes client: %v", err)), nil
-	}
-	namespace, err := ctr.RequireString("namespace")
-	if err != nil {
-		namespace = ""
-	}
-
-	limit := ctr.GetInt("limit", 10)
-
-	continueToken := ctr.GetString("continue", "")
-
-	gvk, err := parseGroupVersionKind(ctr.GetRawArguments().(map[string]interface{}))
-	if err != nil {
-		klog.Errorf("Tool call: get_resources_yaml failed after %v: %v", time.Since(start), err)
-		return NewTextResult("", fmt.Errorf("failed to get YAML, %s", err)), nil
-	}
-
-	name := ctr.GetString("name", "")
-
-	sessionID := getSessionID(ctx)
-	klog.V(1).Infof("Tool: get_resources_yaml - apiVersion: %s, kind: %s, namespace: %s, name: %s - got called by session id: %s", gvk.Version, gvk.Kind, namespace, name, sessionID)
-
-	if name != "" {
-		// Get a specific resource
-		ret, err := k.ResourcesGet(ctx, gvk, namespace, name)
-		duration := time.Since(start)
-		if err != nil {
-			klog.Errorf("Tool call: get_resources_yaml failed after %v: %v", duration, err)
-			return NewTextResult("", fmt.Errorf("failed to get resource YAML: %v", err)), nil
-		}
-		klog.V(1).Infof("Tool call: get_resources_yaml completed successfully in %v by session id: %s", duration, sessionID)
-		return NewTextResult(ret, err), nil
-	} else {
-		// Get all resources of this type in the namespace
-		ret, freshContinueToken, remainingCount, err := k.ResourcesList(ctx, gvk, namespace, int64(limit), continueToken)
-		duration := time.Since(start)
-		if err != nil {
-			klog.Errorf("Tool call: get_resources_yaml failed after %v: %v", duration, err)
-			return NewTextResult("", fmt.Errorf("failed to list resources YAML: %v", err)), nil
-		}
-
-		var data interface{}
-		if err := json.Unmarshal(ret, &data); err != nil {
-			klog.Errorf("Tool call: get_resources_yaml failed to unmarshal response after %v: %v", duration, err)
-			return NewTextResult("", fmt.Errorf("failed to unmarshal resource list: %v", err)), nil
-		}
-
-		response := ListResourceToolOutput{
-			Data:                data,
-			ContinueToken:       freshContinueToken,
-			RemainingItemsCount: remainingCount,
-		}
-
-		jsonBytes, err := json.Marshal(response)
-		if err != nil {
-			klog.Errorf("Tool call: resources_list failed to marshal result to JSON after %v: %v", duration, err)
-			return NewTextResult("", fmt.Errorf("failed to marshal resource list: %v", err)), nil
-		}
-
-		klog.V(1).Infof("Tool call: get_resources_yaml completed successfully in %v by session id: %s", duration, sessionID)
-		return NewTextResult(string(jsonBytes), err), nil
-	}
 }
 
 // func (s *Server) applyManifest(ctx context.Context, ctr mcp.CallToolRequest) (*mcp.CallToolResult, error) {

--- a/pkg/mcp/rollouts.go
+++ b/pkg/mcp/rollouts.go
@@ -33,7 +33,7 @@ func (s *Server) rollout(ctx context.Context, ctr mcp.CallToolRequest) (*mcp.Cal
 	start := time.Now()
 	k, err := s.getKubernetesClient(ctr)
 	if err != nil {
-		klog.Errorf("Tool call: pods_list_in_namespace failed to get Kubernetes client after %v: %v", time.Since(start), err)
+		klog.Errorf("Tool call: rollout failed to get Kubernetes client after %v: %v", time.Since(start), err)
 		return NewTextResult("", fmt.Errorf("failed to initialize Kubernetes client: %v", err)), nil
 	}
 	// Extract required parameters


### PR DESCRIPTION

- Removed the nodes_list and pods_list methods to streamline the API, as they were redundant.
- Updated the resources_list method to include an optional 'view' parameter for output format (JSON or YAML), improving flexibility in response handling.
- Enhanced logging and error handling for resource listing operations to ensure better traceability and debugging.