### PR TITLE
feat: add time filtering parameters to various Kubernetes and MCP methods

### DIFF
--- a/pkg/kubernetes/argocd.go
+++ b/pkg/kubernetes/argocd.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
+	"time"
 )
 
 // ArgoCD API paths
@@ -333,7 +334,7 @@ func (k *Kubernetes) GetApplication(ctx context.Context, name, refresh string) (
 }
 
 // GetApplicationEvents returns events for an ArgoCD application
-func (k *Kubernetes) GetApplicationEvents(ctx context.Context, appName string) (string, error) {
+func (k *Kubernetes) GetApplicationEvents(ctx context.Context, appName string, startTime, endTime *time.Time) (string, error) {
 	if appName == "" {
 		return "", fmt.Errorf("application name is required")
 	}
@@ -342,6 +343,13 @@ func (k *Kubernetes) GetApplicationEvents(ctx context.Context, appName string) (
 
 	params := url.Values{}
 	params.Add("name", appName)
+
+	if startTime != nil && !startTime.IsZero() {
+		params.Add("start_time", fmt.Sprintf("%d", startTime.Unix()))
+	}
+	if endTime != nil && !endTime.IsZero() {
+		params.Add("end_time", fmt.Sprintf("%d", endTime.Unix()))
+	}
 
 	endpoint = fmt.Sprintf("%s?%s", endpoint, params.Encode())
 
@@ -632,7 +640,7 @@ func (k *Kubernetes) GetApplicationManagedResources(ctx context.Context, name st
 }
 
 // GetApplicationWorkloadLogs gets logs for application workload
-func (k *Kubernetes) GetApplicationWorkloadLogs(ctx context.Context, appName, resourceRef, tail, follow string) (string, error) {
+func (k *Kubernetes) GetApplicationWorkloadLogs(ctx context.Context, appName, resourceRef, tail, follow string, startTime, endTime *time.Time) (string, error) {
 	if appName == "" {
 		return "", fmt.Errorf("application name is required")
 	}
@@ -651,6 +659,12 @@ func (k *Kubernetes) GetApplicationWorkloadLogs(ctx context.Context, appName, re
 	if follow != "" {
 		params.Add("follow", follow)
 	}
+	if startTime != nil && !startTime.IsZero() {
+		params.Add("start_time", fmt.Sprintf("%d", startTime.Unix()))
+	}
+	if endTime != nil && !endTime.IsZero() {
+		params.Add("end_time", fmt.Sprintf("%d", endTime.Unix()))
+	}
 
 	endpoint = fmt.Sprintf("%s?%s", endpoint, params.Encode())
 
@@ -662,7 +676,7 @@ func (k *Kubernetes) GetApplicationWorkloadLogs(ctx context.Context, appName, re
 }
 
 // GetApplicationResourceEvents gets events for a resource managed by an application
-func (k *Kubernetes) GetApplicationResourceEvents(ctx context.Context, appName, resourceRef string) (string, error) {
+func (k *Kubernetes) GetApplicationResourceEvents(ctx context.Context, appName, resourceRef string, startTime, endTime *time.Time) (string, error) {
 	if appName == "" {
 		return "", fmt.Errorf("application name is required")
 	}
@@ -675,6 +689,13 @@ func (k *Kubernetes) GetApplicationResourceEvents(ctx context.Context, appName, 
 	params := url.Values{}
 	params.Add("application_name", appName)
 	params.Add("resource_ref", resourceRef)
+
+	if startTime != nil && !startTime.IsZero() {
+		params.Add("start_time", fmt.Sprintf("%d", startTime.Unix()))
+	}
+	if endTime != nil && !endTime.IsZero() {
+		params.Add("end_time", fmt.Sprintf("%d", endTime.Unix()))
+	}
 
 	endpoint = fmt.Sprintf("%s?%s", endpoint, params.Encode())
 

--- a/pkg/kubernetes/events.go
+++ b/pkg/kubernetes/events.go
@@ -2,11 +2,13 @@ package kubernetes
 
 import (
 	"context"
+	"fmt"
 	"net/url"
 	"strings"
+	"time"
 )
 
-func (k *Kubernetes) EventsList(ctx context.Context, namespace string, fieldSelectors []string) (string, error) {
+func (k *Kubernetes) EventsList(ctx context.Context, namespace string, fieldSelectors []string, startTime, endTime *time.Time) (string, error) {
 	// Create the API endpoint URL with query parameters
 	endpoint := "/apis/v1/get-events"
 
@@ -35,6 +37,13 @@ func (k *Kubernetes) EventsList(ctx context.Context, namespace string, fieldSele
 		case "involvedObject.apiVersion":
 			queryParams.Add("involved_object_api_version", value)
 		}
+	}
+
+	if startTime != nil && !startTime.IsZero() {
+		queryParams.Add("start_time", fmt.Sprintf("%d", startTime.Unix()))
+	}
+	if endTime != nil && !endTime.IsZero() {
+		queryParams.Add("end_time", fmt.Sprintf("%d", endTime.Unix()))
 	}
 
 	// Append query parameters to the endpoint if any

--- a/pkg/kubernetes/grafana.go
+++ b/pkg/kubernetes/grafana.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/url"
 	"strings"
+	"time"
 )
 
 // GetDashboardByUID retrieves a dashboard by its UID from Grafana
@@ -68,12 +69,20 @@ func (k *Kubernetes) UpdateDashboard(ctx context.Context, dashboard map[string]i
 }
 
 // GetDashboardPanelQueries extracts panel queries from a dashboard by UID
-func (k *Kubernetes) GetDashboardPanelQueries(ctx context.Context, uid string) (string, error) {
+func (k *Kubernetes) GetDashboardPanelQueries(ctx context.Context, uid string, startTime, endTime *time.Time) (string, error) {
 	if uid == "" {
 		return "", fmt.Errorf("uid parameter is required")
 	}
 
 	endpoint := fmt.Sprintf("/apis/v1/grafana/dashboard-panel-queries?uid=%s", url.QueryEscape(uid))
+	
+	if startTime != nil && !startTime.IsZero() {
+		endpoint = fmt.Sprintf("%s&start_time=%d", endpoint, startTime.Unix())
+	}
+	if endTime != nil && !endTime.IsZero() {
+		endpoint = fmt.Sprintf("%s&end_time=%d", endpoint, endTime.Unix())
+	}
+	
 	response, err := k.MakeAPIRequest("GET", endpoint, nil)
 	if err != nil {
 		return "", fmt.Errorf("failed to get dashboard panel queries: %w", err)

--- a/pkg/kubernetes/pods.go
+++ b/pkg/kubernetes/pods.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/url"
+	"time"
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
@@ -51,12 +52,19 @@ func (k *Kubernetes) PodsDelete(ctx context.Context, namespace, name string) (st
 	return "Pod deleted successfully", nil
 }
 
-func (k *Kubernetes) PodsLog(ctx context.Context, namespace, name string, tailLines int) (string, error) {
+func (k *Kubernetes) PodsLog(ctx context.Context, namespace, name string, tailLines int, startTime, endTime *time.Time) (string, error) {
 	queryParams := url.Values{}
 	queryParams.Add("namespace", namespace)
 	queryParams.Add("pod_name", name)
 	// Use the provided tailLines parameter
 	queryParams.Add("tail_lines", fmt.Sprintf("%d", tailLines))
+
+	if startTime != nil && !startTime.IsZero() {
+		queryParams.Add("start_time", fmt.Sprintf("%d", startTime.Unix()))
+	}
+	if endTime != nil && !endTime.IsZero() {
+		queryParams.Add("end_time", fmt.Sprintf("%d", endTime.Unix()))
+	}
 
 	endpoint := "/apis/v1/pod-logs?" + queryParams.Encode()
 

--- a/pkg/kubernetes/prometheus.go
+++ b/pkg/kubernetes/prometheus.go
@@ -196,9 +196,22 @@ func (k *Kubernetes) GetPrometheusTargetMetadata(matchTarget, metric string, lim
 }
 
 // GetPrometheusAlerts retrieves all currently firing alerts from Prometheus
-func (k *Kubernetes) GetPrometheusAlerts() (string, error) {
+func (k *Kubernetes) GetPrometheusAlerts(startTime, endTime *time.Time) (string, error) {
+	endpoint := "/apis/v1/prometheus/alerts"
+	
+	if startTime != nil && !startTime.IsZero() {
+		endpoint = fmt.Sprintf("%s?start_time=%d", endpoint, startTime.Unix())
+	}
+	if endTime != nil && !endTime.IsZero() {
+		if startTime != nil && !startTime.IsZero() {
+			endpoint = fmt.Sprintf("%s&end_time=%d", endpoint, endTime.Unix())
+		} else {
+			endpoint = fmt.Sprintf("%s?end_time=%d", endpoint, endTime.Unix())
+		}
+	}
+	
 	// Make API request to K8s Dashboard
-	response, err := k.MakeAPIRequest("GET", "/apis/v1/prometheus/alerts", nil)
+	response, err := k.MakeAPIRequest("GET", endpoint, nil)
 	if err != nil {
 		return "", fmt.Errorf("failed to get Prometheus alerts: %w", err)
 	}
@@ -207,7 +220,7 @@ func (k *Kubernetes) GetPrometheusAlerts() (string, error) {
 }
 
 // GetPrometheusRules retrieves information about configured alerting and recording rules
-func (k *Kubernetes) GetPrometheusRules(groupLimit int, ruleNames, ruleGroups, files []string, excludeAlerts bool, matchLabels []string) (string, error) {
+func (k *Kubernetes) GetPrometheusRules(groupLimit int, ruleNames, ruleGroups, files []string, excludeAlerts bool, matchLabels []string, startTime, endTime *time.Time) (string, error) {
 	// Build request body for POST request
 	reqBody := map[string]interface{}{}
 
@@ -234,6 +247,13 @@ func (k *Kubernetes) GetPrometheusRules(groupLimit int, ruleNames, ruleGroups, f
 	// Add group limit if provided
 	if groupLimit > 0 {
 		reqBody["group_limit"] = groupLimit // Send as integer
+	}
+
+	if startTime != nil && !startTime.IsZero() {
+		reqBody["start_time"] = startTime.Unix()
+	}
+	if endTime != nil && !endTime.IsZero() {
+		reqBody["end_time"] = endTime.Unix()
 	}
 
 	// Make API request to K8s Dashboard

--- a/pkg/mcp/argocd.go
+++ b/pkg/mcp/argocd.go
@@ -3,6 +3,7 @@ package mcp
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -57,6 +58,9 @@ func (s *Server) initArgoCD() []server.ServerTool {
 					mcp.Description("The name of the application"),
 					mcp.Required(),
 				),
+				mcp.WithString("start_time", mcp.Description("Start time for event retrieval in RFC3339 format (e.g., '2024-01-01T00:00:00Z') or Unix timestamp. Required if end_time is provided.")),
+				mcp.WithString("end_time", mcp.Description("End time for event retrieval in RFC3339 format (e.g., '2024-01-01T23:59:59Z') or Unix timestamp. Required if start_time is provided.")),
+				mcp.WithString("time_window", mcp.Description("Time range from now (e.g., '1h', '24h', '7d') - alternative to start_time/end_time. If provided, retrieves events from (now - time_window) to now.")),
 			),
 			Handler: s.argocdGetApplicationEvents,
 		},
@@ -220,6 +224,9 @@ func (s *Server) initArgoCD() []server.ServerTool {
 				mcp.WithString("follow",
 					mcp.Description("Follow logs (accepted values: 'true', 'false', default: 'false')"),
 				),
+				mcp.WithString("start_time", mcp.Description("Start time for log retrieval in RFC3339 format (e.g., '2024-01-01T00:00:00Z') or Unix timestamp. Required if end_time is provided.")),
+				mcp.WithString("end_time", mcp.Description("End time for log retrieval in RFC3339 format (e.g., '2024-01-01T23:59:59Z') or Unix timestamp. Required if start_time is provided.")),
+				mcp.WithString("time_window", mcp.Description("Time range from now (e.g., '1h', '24h', '7d') - alternative to start_time/end_time. If provided, retrieves logs from (now - time_window) to now.")),
 			),
 			Handler: s.argocdGetApplicationWorkloadLogs,
 		},
@@ -234,6 +241,9 @@ func (s *Server) initArgoCD() []server.ServerTool {
 					mcp.Description("The resource reference in the format of a map with keys 'name', 'namespace', and optional 'uid'"),
 					mcp.Required(),
 				),
+				mcp.WithString("start_time", mcp.Description("Start time for event retrieval in RFC3339 format (e.g., '2024-01-01T00:00:00Z') or Unix timestamp. Required if end_time is provided.")),
+				mcp.WithString("end_time", mcp.Description("End time for event retrieval in RFC3339 format (e.g., '2024-01-01T23:59:59Z') or Unix timestamp. Required if start_time is provided.")),
+				mcp.WithString("time_window", mcp.Description("Time range from now (e.g., '1h', '24h', '7d') - alternative to start_time/end_time. If provided, retrieves events from (now - time_window) to now.")),
 			),
 			Handler: s.argocdGetResourceEvents,
 		},
@@ -744,6 +754,40 @@ func (s *Server) argocdGetApplicationWorkloadLogs(ctx context.Context, ctr mcp.C
 	followStr := ctr.GetString("follow", "false")
 	follow := strings.ToLower(followStr) == "true"
 
+	startTimeStr := ctr.GetString("start_time", "")
+	endTimeStr := ctr.GetString("end_time", "")
+	timeWindowStr := ctr.GetString("time_window", "")
+
+	var startTime, endTime *time.Time
+	if timeWindowStr != "" {
+		duration, err := time.ParseDuration(timeWindowStr)
+		if err != nil {
+			klog.Errorf("Tool call: argocd_get_application_workload_logs failed after %v: invalid time_window format: %v", time.Since(start), err)
+			return NewTextResult("", fmt.Errorf("invalid time_window format '%s': %v", timeWindowStr, err)), nil
+		}
+		now := time.Now()
+		start := now.Add(-duration)
+		startTime = &start
+		endTime = &now
+	} else if startTimeStr != "" || endTimeStr != "" {
+		if startTimeStr == "" || endTimeStr == "" {
+			klog.Errorf("Tool call: argocd_get_application_workload_logs failed after %v: both start_time and end_time must be provided together", time.Since(start))
+			return NewTextResult("", errors.New("both start_time and end_time must be provided together, or use time_window")), nil
+		}
+		startParsed := parseTime(startTimeStr, time.Time{})
+		if startParsed.IsZero() {
+			klog.Errorf("Tool call: argocd_get_application_workload_logs failed after %v: invalid start_time format", time.Since(start))
+			return NewTextResult("", errors.New("invalid start_time format, use RFC3339 or Unix timestamp")), nil
+		}
+		endParsed := parseTime(endTimeStr, time.Time{})
+		if endParsed.IsZero() {
+			klog.Errorf("Tool call: argocd_get_application_workload_logs failed after %v: invalid end_time format", time.Since(start))
+			return NewTextResult("", errors.New("invalid end_time format, use RFC3339 or Unix timestamp")), nil
+		}
+		startTime = &startParsed
+		endTime = &endParsed
+	}
+
 	klog.V(1).Infof("Tool: argocd_get_application_workload_logs - application: %s, resource: %s/%s/%s, tail: %s, follow: %t - got called",
 		name, resourceRef.Kind, resourceRef.Namespace, resourceRef.Name, tailStr, follow)
 
@@ -751,7 +795,7 @@ func (s *Server) argocdGetApplicationWorkloadLogs(ctx context.Context, ctr mcp.C
 	followStr = fmt.Sprintf("%t", follow)
 	resourceRefJSON, _ := json.Marshal(resourceRef)
 
-	result, err := k.GetApplicationWorkloadLogs(ctx, name, string(resourceRefJSON), followStr, tailStr)
+	result, err := k.GetApplicationWorkloadLogs(ctx, name, string(resourceRefJSON), followStr, tailStr, startTime, endTime)
 	duration := time.Since(start)
 
 	if err != nil {
@@ -799,6 +843,40 @@ func (s *Server) argocdGetResourceEvents(ctx context.Context, ctr mcp.CallToolRe
 		return NewTextResult("", fmt.Errorf("resource_ref.namespace is required")), nil
 	}
 
+	startTimeStr := ctr.GetString("start_time", "")
+	endTimeStr := ctr.GetString("end_time", "")
+	timeWindowStr := ctr.GetString("time_window", "")
+
+	var startTime, endTime *time.Time
+	if timeWindowStr != "" {
+		duration, err := time.ParseDuration(timeWindowStr)
+		if err != nil {
+			klog.Errorf("Tool call: argocd_get_resource_events failed after %v: invalid time_window format: %v", time.Since(start), err)
+			return NewTextResult("", fmt.Errorf("invalid time_window format '%s': %v", timeWindowStr, err)), nil
+		}
+		now := time.Now()
+		start := now.Add(-duration)
+		startTime = &start
+		endTime = &now
+	} else if startTimeStr != "" || endTimeStr != "" {
+		if startTimeStr == "" || endTimeStr == "" {
+			klog.Errorf("Tool call: argocd_get_resource_events failed after %v: both start_time and end_time must be provided together", time.Since(start))
+			return NewTextResult("", errors.New("both start_time and end_time must be provided together, or use time_window")), nil
+		}
+		startParsed := parseTime(startTimeStr, time.Time{})
+		if startParsed.IsZero() {
+			klog.Errorf("Tool call: argocd_get_resource_events failed after %v: invalid start_time format", time.Since(start))
+			return NewTextResult("", errors.New("invalid start_time format, use RFC3339 or Unix timestamp")), nil
+		}
+		endParsed := parseTime(endTimeStr, time.Time{})
+		if endParsed.IsZero() {
+			klog.Errorf("Tool call: argocd_get_resource_events failed after %v: invalid end_time format", time.Since(start))
+			return NewTextResult("", errors.New("invalid end_time format, use RFC3339 or Unix timestamp")), nil
+		}
+		startTime = &startParsed
+		endTime = &endParsed
+	}
+
 	klog.V(1).Infof("Tool: argocd_get_resource_events - application: %s, resource: %s/%s - got called",
 		name, resourceNamespace, resourceName)
 
@@ -808,7 +886,7 @@ func (s *Server) argocdGetResourceEvents(ctx context.Context, ctr mcp.CallToolRe
 		"namespace": resourceNamespace,
 	})
 
-	result, err := k.GetApplicationResourceEvents(ctx, name, string(resourceRefJSON))
+	result, err := k.GetApplicationResourceEvents(ctx, name, string(resourceRefJSON), startTime, endTime)
 	duration := time.Since(start)
 
 	if err != nil {
@@ -1006,10 +1084,44 @@ func (s *Server) argocdGetApplicationEvents(ctx context.Context, ctr mcp.CallToo
 		return NewTextResult("", fmt.Errorf("application name is required")), nil
 	}
 
+	startTimeStr := ctr.GetString("start_time", "")
+	endTimeStr := ctr.GetString("end_time", "")
+	timeWindowStr := ctr.GetString("time_window", "")
+
+	var startTime, endTime *time.Time
+	if timeWindowStr != "" {
+		duration, err := time.ParseDuration(timeWindowStr)
+		if err != nil {
+			klog.Errorf("Tool call: argocd_get_application_events failed after %v: invalid time_window format: %v", time.Since(start), err)
+			return NewTextResult("", fmt.Errorf("invalid time_window format '%s': %v", timeWindowStr, err)), nil
+		}
+		now := time.Now()
+		start := now.Add(-duration)
+		startTime = &start
+		endTime = &now
+	} else if startTimeStr != "" || endTimeStr != "" {
+		if startTimeStr == "" || endTimeStr == "" {
+			klog.Errorf("Tool call: argocd_get_application_events failed after %v: both start_time and end_time must be provided together", time.Since(start))
+			return NewTextResult("", errors.New("both start_time and end_time must be provided together, or use time_window")), nil
+		}
+		startParsed := parseTime(startTimeStr, time.Time{})
+		if startParsed.IsZero() {
+			klog.Errorf("Tool call: argocd_get_application_events failed after %v: invalid start_time format", time.Since(start))
+			return NewTextResult("", errors.New("invalid start_time format, use RFC3339 or Unix timestamp")), nil
+		}
+		endParsed := parseTime(endTimeStr, time.Time{})
+		if endParsed.IsZero() {
+			klog.Errorf("Tool call: argocd_get_application_events failed after %v: invalid end_time format", time.Since(start))
+			return NewTextResult("", errors.New("invalid end_time format, use RFC3339 or Unix timestamp")), nil
+		}
+		startTime = &startParsed
+		endTime = &endParsed
+	}
+
 	klog.V(1).Infof("Tool: argocd_get_application_events - application: %s - got called", name)
 
 	// Get application events using the K8s Dashboard API
-	result, err := k.GetApplicationEvents(ctx, name)
+	result, err := k.GetApplicationEvents(ctx, name, startTime, endTime)
 	duration := time.Since(start)
 
 	if err != nil {

--- a/pkg/mcp/events.go
+++ b/pkg/mcp/events.go
@@ -2,6 +2,7 @@ package mcp
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -22,6 +23,9 @@ func (s *Server) initEvents() []server.ServerTool {
 				mcp.Description("Optional filter to show events only for resources of this kind (e.g. Pod, Deployment)")),
 			mcp.WithString("involved_object_api_version",
 				mcp.Description("Optional filter to show events only for resources with this apiVersion")),
+			mcp.WithString("start_time", mcp.Description("Start time for event retrieval in RFC3339 format (e.g., '2024-01-01T00:00:00Z') or Unix timestamp. Required if end_time is provided.")),
+			mcp.WithString("end_time", mcp.Description("End time for event retrieval in RFC3339 format (e.g., '2024-01-01T23:59:59Z') or Unix timestamp. Required if start_time is provided.")),
+			mcp.WithString("time_window", mcp.Description("Time range from now (e.g., '1h', '24h', '7d') - alternative to start_time/end_time. If provided, retrieves events from (now - time_window) to now.")),
 		), Handler: s.eventsList},
 	}
 }
@@ -29,6 +33,9 @@ func (s *Server) initEvents() []server.ServerTool {
 func (s *Server) eventsList(ctx context.Context, ctr mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	start := time.Now()
 	namespace := ctr.GetString("namespace", "")
+	startTimeStr := ctr.GetString("start_time", "")
+	endTimeStr := ctr.GetString("end_time", "")
+	timeWindowStr := ctr.GetString("time_window", "")
 	k, err := s.getKubernetesClient(ctr)
 	if err != nil {
 		klog.Errorf("Tool call: events_list failed to get Kubernetes client after %v: %v", time.Since(start), err)
@@ -52,11 +59,41 @@ func (s *Server) eventsList(ctx context.Context, ctr mcp.CallToolRequest) (*mcp.
 		fieldSelectors = append(fieldSelectors, fmt.Sprintf("involvedObject.apiVersion=%s", involvedObjectAPIVersion))
 	}
 
+	var startTime, endTime *time.Time
+	if timeWindowStr != "" {
+		duration, err := time.ParseDuration(timeWindowStr)
+		if err != nil {
+			klog.Errorf("Tool call: events_list failed after %v: invalid time_window format: %v", time.Since(start), err)
+			return NewTextResult("", fmt.Errorf("invalid time_window format '%s': %v", timeWindowStr, err)), nil
+		}
+		now := time.Now()
+		start := now.Add(-duration)
+		startTime = &start
+		endTime = &now
+	} else if startTimeStr != "" || endTimeStr != "" {
+		if startTimeStr == "" || endTimeStr == "" {
+			klog.Errorf("Tool call: events_list failed after %v: both start_time and end_time must be provided together", time.Since(start))
+			return NewTextResult("", errors.New("both start_time and end_time must be provided together, or use time_window")), nil
+		}
+		startParsed := parseTime(startTimeStr, time.Time{})
+		if startParsed.IsZero() {
+			klog.Errorf("Tool call: events_list failed after %v: invalid start_time format", time.Since(start))
+			return NewTextResult("", errors.New("invalid start_time format, use RFC3339 or Unix timestamp")), nil
+		}
+		endParsed := parseTime(endTimeStr, time.Time{})
+		if endParsed.IsZero() {
+			klog.Errorf("Tool call: events_list failed after %v: invalid end_time format", time.Since(start))
+			return NewTextResult("", errors.New("invalid end_time format, use RFC3339 or Unix timestamp")), nil
+		}
+		startTime = &startParsed
+		endTime = &endParsed
+	}
+
 	sessionID := getSessionID(ctx)
 	klog.V(1).Infof("Tool: events_list - namespace: %s, involved_object_name: %s, involved_object_kind: %s, involved_object_api_version: %s, field_selectors_count: %d -- got called by session id: %s",
 		namespace, involvedObjectName, involvedObjectKind, involvedObjectAPIVersion, len(fieldSelectors), sessionID)
 
-	ret, err := k.EventsList(ctx, namespace, fieldSelectors)
+	ret, err := k.EventsList(ctx, namespace, fieldSelectors, startTime, endTime)
 	duration := time.Since(start)
 
 	if err != nil {

--- a/pkg/mcp/grafana.go
+++ b/pkg/mcp/grafana.go
@@ -42,8 +42,11 @@ func (s *Server) initGrafana() []server.ServerTool {
 				mcp.Description("User ID for audit trail")),
 		), Handler: s.grafanaUpdateDashboard},
 		{Tool: mcp.NewTool("grafana_get_dashboard_panel_queries",
-			mcp.WithDescription("Inspect data source queries and configurations for specific dashboard panels to analyze data pipelines"),
+			mcp.WithDescription("Inspect data source queries and configurations for specific dashboard panels to analyze data pipelines. If returning query history, time window parameters are required."),
 			mcp.WithString("uid", mcp.Description("The UID of the dashboard"), mcp.Required()),
+			mcp.WithString("start_time", mcp.Description("Start time for query history retrieval in RFC3339 format (e.g., '2024-01-01T00:00:00Z') or Unix timestamp. Required if end_time is provided and tool returns query history.")),
+			mcp.WithString("end_time", mcp.Description("End time for query history retrieval in RFC3339 format (e.g., '2024-01-01T23:59:59Z') or Unix timestamp. Required if start_time is provided and tool returns query history.")),
+			mcp.WithString("time_window", mcp.Description("Time range from now (e.g., '1h', '24h', '7d') - alternative to start_time/end_time. If provided and tool returns query history, retrieves queries from (now - time_window) to now.")),
 		), Handler: s.grafanaGetDashboardPanelQueries},
 		{Tool: mcp.NewTool("grafana_list_datasources",
 			mcp.WithDescription("List all configured data sources with their connection status and type information"),
@@ -260,10 +263,44 @@ func (s *Server) grafanaGetDashboardPanelQueries(ctx context.Context, ctr mcp.Ca
 		return NewTextResult("", errors.New("missing required parameter: uid")), nil
 	}
 
+	startTimeStr := ctr.GetString("start_time", "")
+	endTimeStr := ctr.GetString("end_time", "")
+	timeWindowStr := ctr.GetString("time_window", "")
+
+	var startTime, endTime *time.Time
+	if timeWindowStr != "" {
+		duration, err := time.ParseDuration(timeWindowStr)
+		if err != nil {
+			klog.Errorf("Tool call: grafana_get_dashboard_panel_queries failed after %v: invalid time_window format: %v", time.Since(start), err)
+			return NewTextResult("", fmt.Errorf("invalid time_window format '%s': %v", timeWindowStr, err)), nil
+		}
+		now := time.Now()
+		start := now.Add(-duration)
+		startTime = &start
+		endTime = &now
+	} else if startTimeStr != "" || endTimeStr != "" {
+		if startTimeStr == "" || endTimeStr == "" {
+			klog.Errorf("Tool call: grafana_get_dashboard_panel_queries failed after %v: both start_time and end_time must be provided together", time.Since(start))
+			return NewTextResult("", errors.New("both start_time and end_time must be provided together, or use time_window")), nil
+		}
+		startParsed := parseTime(startTimeStr, time.Time{})
+		if startParsed.IsZero() {
+			klog.Errorf("Tool call: grafana_get_dashboard_panel_queries failed after %v: invalid start_time format", time.Since(start))
+			return NewTextResult("", errors.New("invalid start_time format, use RFC3339 or Unix timestamp")), nil
+		}
+		endParsed := parseTime(endTimeStr, time.Time{})
+		if endParsed.IsZero() {
+			klog.Errorf("Tool call: grafana_get_dashboard_panel_queries failed after %v: invalid end_time format", time.Since(start))
+			return NewTextResult("", errors.New("invalid end_time format, use RFC3339 or Unix timestamp")), nil
+		}
+		startTime = &startParsed
+		endTime = &endParsed
+	}
+
 	klog.V(1).Infof("Tool: grafana_get_dashboard_panel_queries - uid: %s - got called by session id: %s", uid, sessionID)
 
 	// Call the Kubernetes client to get the dashboard panel queries
-	result, err := k.GetDashboardPanelQueries(ctx, uid)
+	result, err := k.GetDashboardPanelQueries(ctx, uid, startTime, endTime)
 	duration := time.Since(start)
 
 	if err != nil {

--- a/pkg/mcp/pods.go
+++ b/pkg/mcp/pods.go
@@ -70,6 +70,9 @@ func (s *Server) initPods() []server.ServerTool {
 			mcp.WithString("namespace", mcp.Description("Namespace to get the Pod logs from")),
 			mcp.WithString("name", mcp.Description("Name of the Pod to get the logs from"), mcp.Required()),
 			mcp.WithNumber("tail_lines", mcp.Description("Number of lines to get from the end of the logs (Optional, default is 256)")),
+			mcp.WithString("start_time", mcp.Description("Start time for log retrieval in RFC3339 format (e.g., '2024-01-01T00:00:00Z') or Unix timestamp. Required if end_time is provided.")),
+			mcp.WithString("end_time", mcp.Description("End time for log retrieval in RFC3339 format (e.g., '2024-01-01T23:59:59Z') or Unix timestamp. Required if start_time is provided.")),
+			mcp.WithString("time_window", mcp.Description("Time range from now (e.g., '1h', '24h', '7d') - alternative to start_time/end_time. If provided, retrieves logs from (now - time_window) to now.")),
 		), Handler: s.podsLog},
 		{Tool: mcp.NewTool("pods_run",
 			mcp.WithDescription("Run a Kubernetes Pod in the current or provided namespace with the provided container image and optional name"),
@@ -213,12 +216,45 @@ func (s *Server) podsLog(ctx context.Context, ctr mcp.CallToolRequest) (*mcp.Cal
 	ns := ctr.GetString("namespace", "")
 	name := ctr.GetString("name", "")
 	tailLines := ctr.GetFloat("tail_lines", 256)
+	startTimeStr := ctr.GetString("start_time", "")
+	endTimeStr := ctr.GetString("end_time", "")
+	timeWindowStr := ctr.GetString("time_window", "")
 	sessionID := getSessionID(ctx)
 	klog.V(1).Infof("Tool: pods_log - getting logs of pod: %s in namespace: %s with tail lines: %.0f - got called by session id: %s", name, ns, tailLines, sessionID)
 
 	if name == "" {
 		klog.Errorf("Tool call: pods_log failed after %v: missing name parameter", time.Since(start))
 		return NewTextResult("", errors.New("failed to get pod log, missing argument name")), nil
+	}
+
+	var startTime, endTime *time.Time
+	if timeWindowStr != "" {
+		duration, err := time.ParseDuration(timeWindowStr)
+		if err != nil {
+			klog.Errorf("Tool call: pods_log failed after %v: invalid time_window format: %v", time.Since(start), err)
+			return NewTextResult("", fmt.Errorf("invalid time_window format '%s': %v", timeWindowStr, err)), nil
+		}
+		now := time.Now()
+		start := now.Add(-duration)
+		startTime = &start
+		endTime = &now
+	} else if startTimeStr != "" || endTimeStr != "" {
+		if startTimeStr == "" || endTimeStr == "" {
+			klog.Errorf("Tool call: pods_log failed after %v: both start_time and end_time must be provided together", time.Since(start))
+			return NewTextResult("", errors.New("both start_time and end_time must be provided together, or use time_window")), nil
+		}
+		startParsed := parseTime(startTimeStr, time.Time{})
+		if startParsed.IsZero() {
+			klog.Errorf("Tool call: pods_log failed after %v: invalid start_time format", time.Since(start))
+			return NewTextResult("", errors.New("invalid start_time format, use RFC3339 or Unix timestamp")), nil
+		}
+		endParsed := parseTime(endTimeStr, time.Time{})
+		if endParsed.IsZero() {
+			klog.Errorf("Tool call: pods_log failed after %v: invalid end_time format", time.Since(start))
+			return NewTextResult("", errors.New("invalid end_time format, use RFC3339 or Unix timestamp")), nil
+		}
+		startTime = &startParsed
+		endTime = &endParsed
 	}
 
 	// Get Kubernetes client from request parameters
@@ -228,7 +264,7 @@ func (s *Server) podsLog(ctx context.Context, ctr mcp.CallToolRequest) (*mcp.Cal
 		return NewTextResult("", fmt.Errorf("failed to initialize Kubernetes client: %v", err)), nil
 	}
 
-	ret, err := k.PodsLog(ctx, ns, name, int(tailLines))
+	ret, err := k.PodsLog(ctx, ns, name, int(tailLines), startTime, endTime)
 	duration := time.Since(start)
 
 	if err != nil {

--- a/pkg/mcp/prometheus.go
+++ b/pkg/mcp/prometheus.go
@@ -22,16 +22,17 @@ func (s *Server) initPrometheus() []server.ServerTool {
 		{Tool: mcp.NewTool("prometheus_metrics_query",
 			mcp.WithDescription("Retrieve current metric values through instant queries to monitor real-time system performance"),
 			mcp.WithString("query", mcp.Description("Prometheus PromQL expression query string"), mcp.Required()),
-			mcp.WithString("time", mcp.Description("Evaluation timestamp in RFC3339 or unix timestamp format (optional)")),
+			mcp.WithString("time", mcp.Description("Evaluation timestamp in RFC3339 or unix timestamp format. Required unless time_window is provided.")),
+			mcp.WithString("time_window", mcp.Description("Time range from now (e.g., '1h', '24h', '7d') - alternative to time. If provided, evaluates query at (now - time_window).")),
 			mcp.WithString("timeout", mcp.Description("Evaluation timeout (optional)")),
 		), Handler: s.prometheusMetrics},
 		{Tool: mcp.NewTool("prometheus_metrics_query_range",
 			mcp.WithDescription("Obtain historical metric data using range queries to analyze trends and performance patterns"),
 			mcp.WithString("query", mcp.Description("Prometheus PromQL expression query string"), mcp.Required()),
-			mcp.WithString("start", mcp.Description("Start timestamp in RFC3339 or Unix timestamp format")),
-			mcp.WithString("end", mcp.Description("End timestamp in RFC3339 or Unix timestamp format")),
-			mcp.WithString("step", mcp.Description("Query resolution step width (e.g., '15s', '1m', '1h')")),
-			mcp.WithString("range", mcp.Description("Time range from now (e.g., '1h', '24h', '7d') - alternative to start/end")),
+			mcp.WithString("start", mcp.Description("Start timestamp in RFC3339 or Unix timestamp format. Required unless range is provided.")),
+			mcp.WithString("end", mcp.Description("End timestamp in RFC3339 or Unix timestamp format. Required unless range is provided.")),
+			mcp.WithString("step", mcp.Description("Query resolution step width (e.g., '15s', '1m', '1h'). Required unless range is provided.")),
+			mcp.WithString("range", mcp.Description("Time range from now (e.g., '1h', '24h', '7d') - alternative to start/end/step. If provided, automatically sets start, end, and step.")),
 			mcp.WithString("timeout", mcp.Description("Evaluation timeout (optional)")),
 		), Handler: s.prometheusMetricsRange},
 		{Tool: mcp.NewTool("prometheus_list_metrics",
@@ -52,8 +53,9 @@ func (s *Server) initPrometheus() []server.ServerTool {
 					}
 				},
 				mcp.Required()),
-			mcp.WithString("start", mcp.Description("Start timestamp in RFC3339 or Unix timestamp format (optional)")),
-			mcp.WithString("end", mcp.Description("End timestamp in RFC3339 or Unix timestamp format (optional)")),
+			mcp.WithString("start", mcp.Description("Start timestamp in RFC3339 or Unix timestamp format. Required unless time_window is provided.")),
+			mcp.WithString("end", mcp.Description("End timestamp in RFC3339 or Unix timestamp format. Required unless time_window is provided.")),
+			mcp.WithString("time_window", mcp.Description("Time range from now (e.g., '1h', '24h', '7d') - alternative to start/end. If provided, queries series from (now - time_window) to now.")),
 			mcp.WithNumber("limit", mcp.Description("Maximum number of returned items (optional)")),
 		), Handler: s.prometheusSeries},
 		{Tool: mcp.NewTool("prometheus_targets",
@@ -98,6 +100,9 @@ func (s *Server) initPrometheus() []server.ServerTool {
 		), Handler: s.prometheusListLabelValues},
 		{Tool: mcp.NewTool("prometheus_get_alerts",
 			mcp.WithDescription("List currently firing alerts to identify active issues requiring attention"),
+			mcp.WithString("start_time", mcp.Description("Start time for alert retrieval in RFC3339 format (e.g., '2024-01-01T00:00:00Z') or Unix timestamp. Required if end_time is provided.")),
+			mcp.WithString("end_time", mcp.Description("End time for alert retrieval in RFC3339 format (e.g., '2024-01-01T23:59:59Z') or Unix timestamp. Required if start_time is provided.")),
+			mcp.WithString("time_window", mcp.Description("Time range from now (e.g., '1h', '24h', '7d') - alternative to start_time/end_time. If provided, retrieves alerts from (now - time_window) to now.")),
 		), Handler: s.prometheusGetAlerts},
 		{Tool: mcp.NewTool("prometheus_get_rules",
 			mcp.WithDescription("Retrieve configured alerting and recording rules to verify their definitions"),
@@ -135,6 +140,9 @@ func (s *Server) initPrometheus() []server.ServerTool {
 				},
 			),
 			mcp.WithNumber("group_limit", mcp.Description("Group limit")),
+			mcp.WithString("start_time", mcp.Description("Start time for rule retrieval in RFC3339 format (e.g., '2024-01-01T00:00:00Z') or Unix timestamp. Required if end_time is provided.")),
+			mcp.WithString("end_time", mcp.Description("End time for rule retrieval in RFC3339 format (e.g., '2024-01-01T23:59:59Z') or Unix timestamp. Required if start_time is provided.")),
+			mcp.WithString("time_window", mcp.Description("Time range from now (e.g., '1h', '24h', '7d') - alternative to start_time/end_time. If provided, retrieves rules from (now - time_window) to now.")),
 		), Handler: s.prometheusGetRules},
 		{Tool: mcp.NewTool("prometheus_create_alert",
 			mcp.WithDescription("Define new alert rules to monitor specific metric conditions and thresholds"),
@@ -185,10 +193,11 @@ func (s *Server) prometheusMetrics(ctx context.Context, ctr mcp.CallToolRequest)
 	}
 	queryArg := ctr.GetString("query", "")
 	timeArg := ctr.GetString("time", "")
+	timeWindowStr := ctr.GetString("time_window", "")
 	timeout := ctr.GetString("timeout", "")
 
 	sessionID := getSessionID(ctx)
-	klog.V(1).Infof("Tool call: prometheus_metrics_query - query=%s, time=%s, timeout=%s - got called by session id: %s", queryArg, timeArg, timeout, sessionID)
+	klog.V(1).Infof("Tool call: prometheus_metrics_query - query=%s, time=%s, time_window=%s, timeout=%s - got called by session id: %s", queryArg, timeArg, timeWindowStr, timeout, sessionID)
 
 	if queryArg == "" {
 		duration := time.Since(start)
@@ -197,13 +206,27 @@ func (s *Server) prometheusMetrics(ctx context.Context, ctr mcp.CallToolRequest)
 	}
 	query := queryArg
 
-	// Extract optional time parameter
+	// Extract time parameter - either time or time_window must be provided
 	var queryTime *time.Time
-	if timeArg != "" {
+	if timeWindowStr != "" {
+		duration, err := time.ParseDuration(timeWindowStr)
+		if err != nil {
+			duration := time.Since(start)
+			klog.Errorf("Tool call: prometheus_metrics_query failed after %v: invalid time_window format: %v by session id: %s", duration, err, sessionID)
+			return NewTextResult("", fmt.Errorf("invalid time_window format '%s': %v", timeWindowStr, err)), nil
+		}
+		now := time.Now()
+		evalTime := now.Add(-duration)
+		queryTime = &evalTime
+	} else if timeArg != "" {
 		parsedTime := parseTime(timeArg, time.Time{})
 		if !parsedTime.IsZero() {
 			queryTime = &parsedTime
 		}
+	} else {
+		duration := time.Since(start)
+		klog.Errorf("Tool call: prometheus_metrics_query failed after %v: missing required parameter: time or time_window by session id: %s", duration, sessionID)
+		return NewTextResult("", errors.New("missing required parameter: either time or time_window must be provided")), nil
 	}
 
 	// Execute the instant query with the provided parameters
@@ -588,25 +611,55 @@ func (s *Server) prometheusSeries(ctx context.Context, ctr mcp.CallToolRequest) 
 		}
 	}
 
-	// Extract optional start parameter
-	var startTime *time.Time
-	if startArg, exists := argsMap["start"]; exists && startArg != nil {
-		if startStr, ok := startArg.(string); ok {
-			parsed := parseTime(startStr, time.Time{})
-			if !parsed.IsZero() {
-				startTime = &parsed
+	// Extract time window parameters - either start/end or time_window must be provided
+	timeWindowStr := ctr.GetString("time_window", "")
+	var startTime, endTime *time.Time
+	
+	if timeWindowStr != "" {
+		duration, err := time.ParseDuration(timeWindowStr)
+		if err != nil {
+			duration := time.Since(start)
+			klog.Errorf("Tool call: prometheus_series_query failed after %v: invalid time_window format: %v by session id: %s", duration, err, sessionID)
+			return NewTextResult("", fmt.Errorf("invalid time_window format '%s': %v", timeWindowStr, err)), nil
+		}
+		now := time.Now()
+		start := now.Add(-duration)
+		startTime = &start
+		endTime = &now
+	} else {
+		// Extract start parameter
+		if startArg, exists := argsMap["start"]; exists && startArg != nil {
+			if startStr, ok := startArg.(string); ok && startStr != "" {
+				parsed := parseTime(startStr, time.Time{})
+				if !parsed.IsZero() {
+					startTime = &parsed
+				} else {
+					duration := time.Since(start)
+					klog.Errorf("Tool call: prometheus_series_query failed after %v: invalid start format by session id: %s", duration, sessionID)
+					return NewTextResult("", errors.New("invalid start format, use RFC3339 or Unix timestamp")), nil
+				}
 			}
 		}
-	}
 
-	// Extract optional end parameter
-	var endTime *time.Time
-	if endArg, exists := argsMap["end"]; exists && endArg != nil {
-		if endStr, ok := endArg.(string); ok {
-			parsed := parseTime(endStr, time.Time{})
-			if !parsed.IsZero() {
-				endTime = &parsed
+		// Extract end parameter
+		if endArg, exists := argsMap["end"]; exists && endArg != nil {
+			if endStr, ok := endArg.(string); ok && endStr != "" {
+				parsed := parseTime(endStr, time.Time{})
+				if !parsed.IsZero() {
+					endTime = &parsed
+				} else {
+					duration := time.Since(start)
+					klog.Errorf("Tool call: prometheus_series_query failed after %v: invalid end format by session id: %s", duration, sessionID)
+					return NewTextResult("", errors.New("invalid end format, use RFC3339 or Unix timestamp")), nil
+				}
 			}
+		}
+
+		// Validate that both start and end are provided if neither time_window is used
+		if startTime == nil || endTime == nil {
+			duration := time.Since(start)
+			klog.Errorf("Tool call: prometheus_series_query failed after %v: both start and end must be provided, or use time_window by session id: %s", duration, sessionID)
+			return NewTextResult("", errors.New("both start and end must be provided, or use time_window")), nil
 		}
 	}
 
@@ -985,11 +1038,46 @@ func (s *Server) prometheusGetAlerts(ctx context.Context, ctr mcp.CallToolReques
 		klog.Errorf("Tool call: prometheus_get_alerts failed to get Kubernetes client after %v: %v", time.Since(start), err)
 		return NewTextResult("", fmt.Errorf("failed to initialize Kubernetes client: %v", err)), nil
 	}
+	
+	startTimeStr := ctr.GetString("start_time", "")
+	endTimeStr := ctr.GetString("end_time", "")
+	timeWindowStr := ctr.GetString("time_window", "")
+
+	var startTime, endTime *time.Time
+	if timeWindowStr != "" {
+		duration, err := time.ParseDuration(timeWindowStr)
+		if err != nil {
+			klog.Errorf("Tool call: prometheus_get_alerts failed after %v: invalid time_window format: %v", time.Since(start), err)
+			return NewTextResult("", fmt.Errorf("invalid time_window format '%s': %v", timeWindowStr, err)), nil
+		}
+		now := time.Now()
+		start := now.Add(-duration)
+		startTime = &start
+		endTime = &now
+	} else if startTimeStr != "" || endTimeStr != "" {
+		if startTimeStr == "" || endTimeStr == "" {
+			klog.Errorf("Tool call: prometheus_get_alerts failed after %v: both start_time and end_time must be provided together", time.Since(start))
+			return NewTextResult("", errors.New("both start_time and end_time must be provided together, or use time_window")), nil
+		}
+		startParsed := parseTime(startTimeStr, time.Time{})
+		if startParsed.IsZero() {
+			klog.Errorf("Tool call: prometheus_get_alerts failed after %v: invalid start_time format", time.Since(start))
+			return NewTextResult("", errors.New("invalid start_time format, use RFC3339 or Unix timestamp")), nil
+		}
+		endParsed := parseTime(endTimeStr, time.Time{})
+		if endParsed.IsZero() {
+			klog.Errorf("Tool call: prometheus_get_alerts failed after %v: invalid end_time format", time.Since(start))
+			return NewTextResult("", errors.New("invalid end_time format, use RFC3339 or Unix timestamp")), nil
+		}
+		startTime = &startParsed
+		endTime = &endParsed
+	}
+
 	sessionID := getSessionID(ctx)
 	klog.V(1).Infof("Tool: prometheus_get_alerts - got called by session id: %s", sessionID)
 
 	// Call the Kubernetes function
-	ret, err := k.GetPrometheusAlerts()
+	ret, err := k.GetPrometheusAlerts(startTime, endTime)
 	if err != nil {
 		duration := time.Since(start)
 		klog.Errorf("Tool call: prometheus_get_alerts failed after %v: %v by session id: %s", duration, err, sessionID)
@@ -1072,12 +1160,46 @@ func (s *Server) prometheusGetRules(ctx context.Context, ctr mcp.CallToolRequest
 	// Extract group_limit parameter (number) using GetFloat
 	groupLimit := int(ctr.GetFloat("group_limit", 0))
 
+	startTimeStr := ctr.GetString("start_time", "")
+	endTimeStr := ctr.GetString("end_time", "")
+	timeWindowStr := ctr.GetString("time_window", "")
+
+	var startTime, endTime *time.Time
+	if timeWindowStr != "" {
+		duration, err := time.ParseDuration(timeWindowStr)
+		if err != nil {
+			klog.Errorf("Tool call: prometheus_get_rules failed after %v: invalid time_window format: %v", time.Since(start), err)
+			return NewTextResult("", fmt.Errorf("invalid time_window format '%s': %v", timeWindowStr, err)), nil
+		}
+		now := time.Now()
+		start := now.Add(-duration)
+		startTime = &start
+		endTime = &now
+	} else if startTimeStr != "" || endTimeStr != "" {
+		if startTimeStr == "" || endTimeStr == "" {
+			klog.Errorf("Tool call: prometheus_get_rules failed after %v: both start_time and end_time must be provided together", time.Since(start))
+			return NewTextResult("", errors.New("both start_time and end_time must be provided together, or use time_window")), nil
+		}
+		startParsed := parseTime(startTimeStr, time.Time{})
+		if startParsed.IsZero() {
+			klog.Errorf("Tool call: prometheus_get_rules failed after %v: invalid start_time format", time.Since(start))
+			return NewTextResult("", errors.New("invalid start_time format, use RFC3339 or Unix timestamp")), nil
+		}
+		endParsed := parseTime(endTimeStr, time.Time{})
+		if endParsed.IsZero() {
+			klog.Errorf("Tool call: prometheus_get_rules failed after %v: invalid end_time format", time.Since(start))
+			return NewTextResult("", errors.New("invalid end_time format, use RFC3339 or Unix timestamp")), nil
+		}
+		startTime = &startParsed
+		endTime = &endParsed
+	}
+
 	sessionID := getSessionID(ctx)
 	klog.V(1).Infof("Tool: prometheus_get_rules - rule_names_count=%d, rule_groups_count=%d, files_count=%d, exclude_alerts=%t, match_labels_count=%d, group_limit=%d - got called by session id: %s",
 		len(ruleNames), len(ruleGroups), len(files), excludeAlerts, len(matchLabels), groupLimit, sessionID)
 
 	// Call the Kubernetes function
-	ret, err := k.GetPrometheusRules(groupLimit, ruleNames, ruleGroups, files, excludeAlerts, matchLabels)
+	ret, err := k.GetPrometheusRules(groupLimit, ruleNames, ruleGroups, files, excludeAlerts, matchLabels, startTime, endTime)
 	if err != nil {
 		duration := time.Since(start)
 		klog.Errorf("Tool call: prometheus_get_rules failed after %v: %v by session id: %s", duration, err, sessionID)


### PR DESCRIPTION
- Enhanced GetApplicationEvents, GetApplicationWorkloadLogs, GetApplicationResourceEvents, and other methods to accept optional start_time and end_time parameters for filtering results based on time.
- Updated MCP tools to include time filtering options, allowing users to specify time windows for event and log retrieval.
- Improved input schema descriptions to clarify the usage of start_time, end_time, and time_window parameters across multiple tools.