### PR TITLE
fix(prometheus): send rule query times as strings

### DIFF
--- a/pkg/kubernetes/kubernetes_test.go
+++ b/pkg/kubernetes/kubernetes_test.go
@@ -1,9 +1,12 @@
 package kubernetes
 
 import (
+	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 )
 
 func TestSlimTransport_RoundTrip(t *testing.T) {
@@ -130,5 +133,46 @@ func TestNewHTTPClient_UsesSlimTransport(t *testing.T) {
 
 	if _, ok := client.Client.Transport.(*SlimTransport); !ok {
 		t.Error("HTTPClient does not use SlimTransport")
+	}
+}
+
+func TestGetPrometheusRules_SendsStringTimes(t *testing.T) {
+	var body map[string]any
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/apis/v1/prometheus/rules" {
+			t.Fatalf("path = %q, want /apis/v1/prometheus/rules", r.URL.Path)
+		}
+		if r.Method != http.MethodPost {
+			t.Fatalf("method = %q, want POST", r.Method)
+		}
+
+		raw, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("failed to read request body: %v", err)
+		}
+		if err := json.Unmarshal(raw, &body); err != nil {
+			t.Fatalf("failed to decode request body: %v", err)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"status":"success"}`))
+	}))
+	defer server.Close()
+
+	client := &Kubernetes{HTTPClient: NewHTTPClient(server.URL, "test-token")}
+	start := time.Date(2026, 6, 19, 12, 1, 24, 0, time.UTC)
+	end := start.Add(15 * time.Minute)
+
+	if _, err := client.GetPrometheusRules(0, []string{"AfterdoQAPodCrashLoop"}, nil, nil, false, nil, &start, &end); err != nil {
+		t.Fatalf("GetPrometheusRules failed: %v", err)
+	}
+
+	if got, ok := body["start_time"].(string); !ok || got != "2026-06-19T12:01:24Z" {
+		t.Fatalf("start_time = %#v, want RFC3339 string", body["start_time"])
+	}
+	if got, ok := body["end_time"].(string); !ok || got != "2026-06-19T12:16:24Z" {
+		t.Fatalf("end_time = %#v, want RFC3339 string", body["end_time"])
 	}
 }

--- a/pkg/kubernetes/prometheus.go
+++ b/pkg/kubernetes/prometheus.go
@@ -248,10 +248,10 @@ func (k *Kubernetes) GetPrometheusRules(groupLimit int, ruleNames, ruleGroups, f
 	}
 
 	if startTime != nil && !startTime.IsZero() {
-		reqBody["start_time"] = startTime.Unix()
+		reqBody["start_time"] = startTime.Format(time.RFC3339)
 	}
 	if endTime != nil && !endTime.IsZero() {
-		reqBody["end_time"] = endTime.Unix()
+		reqBody["end_time"] = endTime.Format(time.RFC3339)
 	}
 
 	// Make API request to K8s Dashboard


### PR DESCRIPTION
## Summary
- send Prometheus rules start_time/end_time as RFC3339 strings instead of Unix numbers
- add regression coverage for the rules request body contract

## Why
PP RCA testing showed prometheus_get_rules failing with HTTP 400 because the agent API expects string start_time/end_time fields.

## Test
- go test ./pkg/kubernetes ./pkg/mcp