### PR TITLE
fix(prometheus): send rule query unix times as strings

### DIFF
--- a/pkg/kubernetes/kubernetes_test.go
+++ b/pkg/kubernetes/kubernetes_test.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"testing"
 	"time"
 )
@@ -169,10 +170,10 @@ func TestGetPrometheusRules_SendsStringTimes(t *testing.T) {
 		t.Fatalf("GetPrometheusRules failed: %v", err)
 	}
 
-	if got, ok := body["start_time"].(string); !ok || got != "2026-06-19T12:01:24Z" {
-		t.Fatalf("start_time = %#v, want RFC3339 string", body["start_time"])
+	if got, ok := body["start_time"].(string); !ok || got != strconv.FormatInt(start.Unix(), 10) {
+		t.Fatalf("start_time = %#v, want Unix timestamp string", body["start_time"])
 	}
-	if got, ok := body["end_time"].(string); !ok || got != "2026-06-19T12:16:24Z" {
-		t.Fatalf("end_time = %#v, want RFC3339 string", body["end_time"])
+	if got, ok := body["end_time"].(string); !ok || got != strconv.FormatInt(end.Unix(), 10) {
+		t.Fatalf("end_time = %#v, want Unix timestamp string", body["end_time"])
 	}
 }

--- a/pkg/kubernetes/prometheus.go
+++ b/pkg/kubernetes/prometheus.go
@@ -3,6 +3,7 @@ package kubernetes
 import (
 	"fmt"
 	"net/url"
+	"strconv"
 	"strings"
 	"time"
 
@@ -248,10 +249,10 @@ func (k *Kubernetes) GetPrometheusRules(groupLimit int, ruleNames, ruleGroups, f
 	}
 
 	if startTime != nil && !startTime.IsZero() {
-		reqBody["start_time"] = startTime.Format(time.RFC3339)
+		reqBody["start_time"] = strconv.FormatInt(startTime.Unix(), 10)
 	}
 	if endTime != nil && !endTime.IsZero() {
-		reqBody["end_time"] = endTime.Format(time.RFC3339)
+		reqBody["end_time"] = strconv.FormatInt(endTime.Unix(), 10)
 	}
 
 	// Make API request to K8s Dashboard


### PR DESCRIPTION
## Summary
- send Prometheus rules start_time/end_time as Unix timestamp strings
- keep the public MCP schema as string while matching the downstream agent API contract
- update regression coverage to verify the exact request body type and format

## Verification
- go test ./pkg/kubernetes ./pkg/mcp
- make test
- make build

## PP evidence
PP testing showed the downstream agent rejects numeric JSON values and RFC3339 strings for /apis/v1/prometheus/rules; it expects Unix timestamps encoded as strings.